### PR TITLE
fix: production hardening for logging safety and CI release quality gates

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -135,7 +135,7 @@ jobs:
     - name: Get Previous Version
       id: version
       env:
-       GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         $latest = gh release list --limit 1 --json tagName | ConvertFrom-Json
         if ($latest) {

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -3,11 +3,18 @@ name: Production Build
 on:
   push:
     branches:
+      - main
       - master
       - New-Ci-Pipeline
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+      - master
 
 jobs:
-  build:
+  build_and_test:
     runs-on: windows-latest
 
     env:
@@ -56,10 +63,63 @@ jobs:
     # 7. TEST
     # -------------------------
     - name: Run Tests
-      run: dotnet test PocketMC.Desktop.sln --no-build
+      run: dotnet test PocketMC.Desktop.sln --no-build --collect:"XPlat Code Coverage"
 
     # -------------------------
-    # 8. PUBLISH MULTI-DLL
+    # 8. VULNERABILITY AUDIT
+    # -------------------------
+    - name: Audit NuGet vulnerabilities
+      run: dotnet list PocketMC.Desktop.sln package --vulnerable --include-transitive
+
+    # -------------------------
+    # 9. UPLOAD TEST ARTIFACTS
+    # -------------------------
+    - name: Upload test results and coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results-and-coverage
+        path: |
+          **/TestResults/**
+          **/coverage.cobertura.xml
+      if: always()
+
+  package_release:
+    if: github.event_name == 'push'
+    needs: build_and_test
+    runs-on: windows-latest
+
+    env:
+      DOTNET_VERSION: '8.0.x'
+      RUNTIME: win-x64
+      APP_ID: PocketMC
+
+    steps:
+    # -------------------------
+    # 1. CHECKOUT
+    # -------------------------
+    - uses: actions/checkout@v4
+
+    # -------------------------
+    # 2. SETUP DEPENDENCIES
+    # -------------------------
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    # -------------------------
+    # 3. ADD TOOL PATH
+    # -------------------------
+    - name: Add .NET tools to PATH
+      run: echo "$env:USERPROFILE\.dotnet\tools" >> $env:GITHUB_PATH
+
+    # -------------------------
+    # 4. INSTALL VELOPACK CLI
+    # -------------------------
+    - name: Install Velopack
+      run: dotnet tool install -g vpk
+
+    # -------------------------
+    # 5. PUBLISH MULTI-DLL
     # -------------------------
     - name: Publish Multi-DLL
       run: |
@@ -70,7 +130,7 @@ jobs:
           -o publish
 
     # -------------------------
-    # 10. GET PREVIOUS VERSION
+    # 6. GET PREVIOUS VERSION
     # -------------------------
     - name: Get Previous Version
       id: version
@@ -93,7 +153,7 @@ jobs:
         echo "VERSION=$newVersion" >> $env:GITHUB_ENV
 
     # -------------------------
-    # 11. DOWNLOAD PREVIOUS RELEASE
+    # 7. DOWNLOAD PREVIOUS RELEASE
     # -------------------------
     - name: Download previous release
       uses: robinraju/release-downloader@v1
@@ -103,13 +163,13 @@ jobs:
       continue-on-error: true
 
     # -------------------------
-    # 12. VELOPACK PACKAGE
+    # 8. VELOPACK PACKAGE
     # -------------------------
     - name: Pack with Velopack
       run: vpk pack --packId ${{ env.APP_ID }} --packVersion ${{ env.VERSION }} --packDir publish --mainExe PocketMC.Desktop.exe --framework net8.0 --runtime ${{ env.RUNTIME }} --outputDir Releases
 
     # -------------------------
-    # 13. UPLOAD RELEASE ARTIFACTS
+    # 9. UPLOAD RELEASE ARTIFACTS
     # -------------------------
     - name: Upload Release Artifacts
       uses: actions/upload-artifact@v4

--- a/PocketMC.Desktop.Tests/MinecraftMotdConverterTests.cs
+++ b/PocketMC.Desktop.Tests/MinecraftMotdConverterTests.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using System.Windows.Data;
+using PocketMC.Desktop.Features.Settings;
+
+namespace PocketMC.Desktop.Tests;
+
+public class MinecraftMotdConverterTests
+{
+    [Fact]
+    public void ConvertBack_ReturnsBindingDoNothing()
+    {
+        var converter = new MinecraftMotdConverter();
+
+        var result = converter.ConvertBack("ignored", typeof(string), null, CultureInfo.InvariantCulture);
+
+        Assert.Same(Binding.DoNothing, result);
+    }
+}

--- a/PocketMC.Desktop.Tests/PocketMC.Desktop.Tests.csproj
+++ b/PocketMC.Desktop.Tests/PocketMC.Desktop.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);NU1701</NoWarn>

--- a/PocketMC.Desktop.Tests/RollingFileLoggerProviderTests.cs
+++ b/PocketMC.Desktop.Tests/RollingFileLoggerProviderTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging;
+using PocketMC.Desktop.Infrastructure.Logging;
+
+namespace PocketMC.Desktop.Tests;
+
+public class RollingFileLoggerProviderTests
+{
+    [Fact]
+    public void Provider_WritesLogsToExpectedDailyFile()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "pocketmc-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            using var provider = new RollingFileLoggerProvider(directory, LogLevel.Information, retainedFileCount: 5);
+            var logger = provider.CreateLogger("PocketMC.Tests");
+
+            logger.LogInformation("Structured startup event for {Subsystem}", "logging");
+
+            string expectedPath = Path.Combine(directory, $"pocketmc-{DateTime.UtcNow:yyyyMMdd}.log");
+            Assert.True(File.Exists(expectedPath));
+
+            string contents = File.ReadAllText(expectedPath);
+            Assert.Contains("Structured startup event", contents);
+            Assert.Contains("[Information]", contents);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/PocketMC.Desktop/App.xaml.cs
+++ b/PocketMC.Desktop/App.xaml.cs
@@ -23,9 +23,8 @@ using PocketMC.Desktop.Features.Instances.Backups;
 using PocketMC.Desktop.Features.Java;
 using PocketMC.Desktop.Features.Intelligence;
 using PocketMC.Desktop.Composition;
+using PocketMC.Desktop.Infrastructure.Logging;
 
-using System.Net.Http;
-using System.Net;
 using System.IO;
 
 namespace PocketMC.Desktop;
@@ -41,12 +40,14 @@ public partial class App : Application
     {
         base.OnStartup(e);
         WindowsToastNotificationService.RegisterApplication();
+        string appLogDirectory = GetAppLogDirectory();
 
         _host = Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>
             {
                 logging.ClearProviders();
                 logging.AddDebug();
+                logging.AddProvider(new RollingFileLoggerProvider(appLogDirectory, LogLevel.Information, retainedFileCount: 14));
             })
             .ConfigureServices(services =>
             {
@@ -143,11 +144,7 @@ public partial class App : Application
 
     private static string WriteCrashReport(Exception exception, string source)
     {
-        string logDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "PocketMC",
-            "logs");
-
+        string logDirectory = GetAppLogDirectory();
         Directory.CreateDirectory(logDirectory);
 
         string crashReportPath = Path.Combine(
@@ -165,8 +162,11 @@ public partial class App : Application
         return crashReportPath;
     }
 
-    private static void SetDefaultUserAgent(HttpClient client)
+    private static string GetAppLogDirectory()
     {
-        client.DefaultRequestHeaders.Add("User-Agent", "PocketMC-Desktop/1.0");
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "PocketMC",
+            "logs");
     }
 }

--- a/PocketMC.Desktop/App.xaml.cs
+++ b/PocketMC.Desktop/App.xaml.cs
@@ -10,7 +10,6 @@ using PocketMC.Desktop.Features.Shell;
 using PocketMC.Desktop.Features.Dashboard;
 using PocketMC.Desktop.Features.Settings;
 using PocketMC.Desktop.Features.InstanceCreation;
-using PocketMC.Desktop.Features.Console;
 using PocketMC.Desktop.Features.Marketplace;
 using PocketMC.Desktop.Features.Tunnel;
 using PocketMC.Desktop.Features.Setup;
@@ -49,7 +48,10 @@ public partial class App : Application
 #if DEBUG
                 logging.AddDebug();
 #endif
-                logging.AddProvider(new RollingFileLoggerProvider(appLogDirectory, LogLevel.Information, retainedFileCount: 14));
+                logging.AddProvider(new RollingFileLoggerProvider(
+                    appLogDirectory,
+                    Microsoft.Extensions.Logging.LogLevel.Information,
+                    retainedFileCount: 14));
             })
             .ConfigureServices(services =>
             {

--- a/PocketMC.Desktop/App.xaml.cs
+++ b/PocketMC.Desktop/App.xaml.cs
@@ -46,7 +46,9 @@ public partial class App : Application
             .ConfigureLogging(logging =>
             {
                 logging.ClearProviders();
+#if DEBUG
                 logging.AddDebug();
+#endif
                 logging.AddProvider(new RollingFileLoggerProvider(appLogDirectory, LogLevel.Information, retainedFileCount: 14));
             })
             .ConfigureServices(services =>

--- a/PocketMC.Desktop/Features/Diagnostics/DiagnosticReportingService.cs
+++ b/PocketMC.Desktop/Features/Diagnostics/DiagnosticReportingService.cs
@@ -84,7 +84,7 @@ public class DiagnosticReportingService
                 var instanceDir = Path.Combine(outServers, instance.Id.ToString());
                 Directory.CreateDirectory(instanceDir);
 
-                string originalPath = _instanceRegistry.GetPath(instance.Id);
+                string? originalPath = _instanceRegistry.GetPath(instance.Id);
                 if (originalPath == null || !Directory.Exists(originalPath)) continue;
 
                 // Copy .pocket-mc.json

--- a/PocketMC.Desktop/Features/Settings/MinecraftMotdConverter.cs
+++ b/PocketMC.Desktop/Features/Settings/MinecraftMotdConverter.cs
@@ -102,7 +102,7 @@ namespace PocketMC.Desktop.Features.Settings
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }

--- a/PocketMC.Desktop/Infrastructure/Logging/RollingFileLoggerProvider.cs
+++ b/PocketMC.Desktop/Infrastructure/Logging/RollingFileLoggerProvider.cs
@@ -103,9 +103,16 @@ public sealed class RollingFileLoggerProvider : ILoggerProvider
 
             string filePath = Path.Combine(_logDirectory, $"pocketmc-{timestamp:yyyyMMdd}.log");
 
-            lock (Gate)
+            try
             {
-                File.AppendAllText(filePath, line);
+                lock (Gate)
+                {
+                    File.AppendAllText(filePath, line);
+                }
+            }
+            catch
+            {
+                // Logging failures must never take down the app.
             }
         }
 

--- a/PocketMC.Desktop/Infrastructure/Logging/RollingFileLoggerProvider.cs
+++ b/PocketMC.Desktop/Infrastructure/Logging/RollingFileLoggerProvider.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace PocketMC.Desktop.Infrastructure.Logging;
+
+public sealed class RollingFileLoggerProvider : ILoggerProvider
+{
+    private readonly string _logDirectory;
+    private readonly LogLevel _minimumLevel;
+    private readonly int _retainedFileCount;
+    private readonly ConcurrentDictionary<string, RollingFileLogger> _loggers = new(StringComparer.OrdinalIgnoreCase);
+
+    public RollingFileLoggerProvider(string logDirectory, LogLevel minimumLevel = LogLevel.Information, int retainedFileCount = 10)
+    {
+        _logDirectory = logDirectory;
+        _minimumLevel = minimumLevel;
+        _retainedFileCount = Math.Max(1, retainedFileCount);
+
+        Directory.CreateDirectory(_logDirectory);
+        DeleteOldLogs();
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return _loggers.GetOrAdd(categoryName, category => new RollingFileLogger(category, _logDirectory, _minimumLevel));
+    }
+
+    public void Dispose()
+    {
+        _loggers.Clear();
+    }
+
+    private void DeleteOldLogs()
+    {
+        var files = new DirectoryInfo(_logDirectory)
+            .GetFiles("pocketmc-*.log")
+            .OrderByDescending(file => file.LastWriteTimeUtc)
+            .Skip(_retainedFileCount);
+
+        foreach (var file in files)
+        {
+            try
+            {
+                file.Delete();
+            }
+            catch
+            {
+                // Non-fatal: retention cleanup should never crash startup.
+            }
+        }
+    }
+
+    private sealed class RollingFileLogger : ILogger
+    {
+        private static readonly object Gate = new();
+
+        private readonly string _categoryName;
+        private readonly string _logDirectory;
+        private readonly LogLevel _minimumLevel;
+
+        public RollingFileLogger(string categoryName, string logDirectory, LogLevel minimumLevel)
+        {
+            _categoryName = categoryName;
+            _logDirectory = logDirectory;
+            _minimumLevel = minimumLevel;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= _minimumLevel;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            var timestamp = DateTime.UtcNow;
+            string message = formatter(state, exception);
+            if (string.IsNullOrWhiteSpace(message) && exception is null)
+            {
+                return;
+            }
+
+            string line = string.Create(
+                CultureInfo.InvariantCulture,
+                $"{timestamp:O} [{logLevel}] {_categoryName} ({eventId.Id}): {message}{Environment.NewLine}");
+
+            if (exception is not null)
+            {
+                line += exception + Environment.NewLine;
+            }
+
+            string filePath = Path.Combine(_logDirectory, $"pocketmc-{timestamp:yyyyMMdd}.log");
+
+            lock (Gate)
+            {
+                File.AppendAllText(filePath, line);
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/docs/production-readiness-review-2026-04-16.md
+++ b/docs/production-readiness-review-2026-04-16.md
@@ -1,0 +1,87 @@
+# PocketMC Desktop Production Readiness Review (2026-04-16)
+
+## Scope
+
+This review is based on repository inspection of runtime composition, exception handling, diagnostics, CI/CD workflow configuration, and test/project setup.
+
+## Executive Verdict
+
+**Status: Conditionally ready (not fully production-ready yet).**
+
+The app has strong foundations (global crash handling, dependency-injected architecture, path-safety tests, updater integration), but there are release-readiness risks that should be closed before broad production rollout.
+
+---
+
+## Strengths
+
+1. **Global unhandled exception capture and crash report persistence exists.**
+   - App wires UI thread, AppDomain, and unobserved task exception handlers and writes crash logs to `%LocalAppData%/PocketMC/logs`.
+2. **Security hardening appears intentional in file handling and backups.**
+   - Tests cover path traversal and ZIP extraction safety.
+   - Diagnostics redact `rcon.password` in exported server properties.
+3. **Auto-update flow has lifecycle controls.**
+   - Update checks are semaphore-guarded to avoid concurrent update cycles.
+
+---
+
+## Production Blockers / High-Priority Risks
+
+### 1) CI workflow scope should be explicitly tied to your canonical release branch
+
+- Workflow `production-build.yml` currently triggers on `master` and `New-Ci-Pipeline`.
+- This is correct **if `master` is your canonical release branch**. If your team releases from `main` or tags, the trigger should be updated accordingly.
+
+**Risk:** If repository release practices drift from these configured branch triggers, production packaging may silently stop running for expected release pushes.
+
+**Recommendation:**
+- Keep `master` trigger if that is the intended release branch.
+- If releases are cut from `main` or tags, add those triggers explicitly (for example semver tags like `v*`).
+- Split CI (build/test) from release (pack/publish) if needed.
+
+### 2) Local observability gap for production support
+
+- App logging is configured with `AddDebug()` only.
+
+**Risk:** Debug provider is often insufficient for post-mortem production support outside dev tooling; field diagnostics depend mostly on crash files and ad hoc bundle generation.
+
+**Recommendation:**
+- Add structured file logging (rolling files under `%LocalAppData%/PocketMC/logs`) and include correlation IDs per server instance/session.
+
+### 3) Unimplemented converter reverse path can crash if binding mode changes
+
+- `MinecraftMotdConverter.ConvertBack` throws `NotImplementedException`.
+
+**Risk:** If a two-way binding or refactor accidentally exercises `ConvertBack`, the settings UX can fail at runtime.
+
+**Recommendation:**
+- Return `Binding.DoNothing` for unsupported convert-back scenarios or explicitly enforce one-way binding in XAML where used.
+
+---
+
+## Medium-Priority Improvements
+
+1. **Dependency/version maintenance policy not enforced in CI**
+   - No automated vulnerability scan / package audit gate in workflow.
+2. **Coverage signal is weak in pipeline**
+   - Tests run, but there is no minimum coverage threshold or report publishing gate.
+3. **Release process coupling**
+   - Build, test, versioning, packing, and artifact upload all happen in one workflow/job; failures can reduce diagnosability.
+
+---
+
+## Suggested Go-Live Checklist
+
+Before broad production rollout, complete:
+
+- [ ] Confirm workflow triggers match your real release source (`master` vs `main` and/or release tags).
+- [ ] Add persistent file logging for release builds.
+- [ ] Remove runtime `NotImplementedException` from value converters in UI paths.
+- [ ] Add dependency vulnerability audit in CI.
+- [ ] Publish test + coverage artifacts and define a minimum quality gate.
+- [ ] Perform one clean-room install/update rollback validation on a fresh Windows 10 and Windows 11 machine.
+
+---
+
+## Overall Assessment
+
+PocketMC is **close** to production-grade for controlled rollout, especially for technically experienced users. For a broad public release, the CI trigger alignment and production observability items should be addressed first to reduce operational risk.


### PR DESCRIPTION
### Motivation

- Implement runtime and CI fixes identified by the production readiness review to reduce operational risk before a broad rollout, focusing on persistent diagnostics, avoiding UI crashes from value converters, and improving CI/release gating.

### Description

- Added `RollingFileLoggerProvider` that writes daily logs to `%LocalAppData%/PocketMC/logs`, performs retention cleanup, and wired it into startup logging via `App.xaml.cs` while centralizing the app log directory helper.
- Replaced the `MinecraftMotdConverter.ConvertBack` exception with `Binding.DoNothing` to prevent accidental runtime crashes from two-way bindings. 
- Added unit tests `MinecraftMotdConverterTests` and `RollingFileLoggerProviderTests` to cover the converter and logger behavior. 
- Hardened the GitHub Actions workflow (`.github/workflows/production-build.yml`) by adding `main` and tag triggers, splitting `build_and_test` from `package_release`, enabling coverage collection and artifact upload, and adding a NuGet vulnerability audit step.

### Testing

- Unit tests were added (`MinecraftMotdConverterTests`, `RollingFileLoggerProviderTests`) but executing them in this environment failed because the .NET SDK is not installed (`dotnet test` reported `dotnet: command not found`).
- CI-facing checks (coverage collection and NuGet vulnerability audit) are configured in the updated workflow and will run on GitHub Actions when the workflow is triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0287e61bc8333922bbe77022d5bfc)