### PR TITLE
Treat `view-distance` as advanced property (fix ServerConfigurationService core keys)

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - New-Ci-Pipeline
+  pull_request:
 
 jobs:
   build:

--- a/PocketMC.Desktop/Features/Instances/Services/ServerConfigurationService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/ServerConfigurationService.cs
@@ -45,7 +45,6 @@ public sealed class ServerConfigurationService
         "server-name",              // PM uses this instead of motd
         "enable-query",
         "auto-save",
-        "view-distance",
         "language",
     };
 


### PR DESCRIPTION
### Motivation
- Ensure `view-distance` is treated as an advanced (non-core) server property so settings and tests that expect it in `AdvancedProperties` remain correct.

### Description
- Removed the `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0952750fc83339fe18b0812208f3a)