### PR TITLE
Switch Geyser/Floodgate provisioning to Modrinth compatibility-aware installs

### DIFF
--- a/PocketMC.Desktop/Features/InstanceCreation/NewInstancePage.xaml.cs
+++ b/PocketMC.Desktop/Features/InstanceCreation/NewInstancePage.xaml.cs
@@ -344,11 +344,34 @@ namespace PocketMC.Desktop.Features.InstanceCreation
                 if (ChkEnableGeyser.IsChecked == true && createdInstancePath != null)
                 {
                     TxtProgress.Text = "Setting up Geyser cross-play...";
-                    await _geyserProvisioning.EnsureGeyserSetupAsync(createdInstancePath, serverType, selectedVersion.Id, progress);
 
-                    // Persist the HasGeyser flag so the dashboard shows the Bedrock IP row
-                    metadata.HasGeyser = true;
-                    _instanceManager.SaveMetadata(metadata, createdInstancePath);
+                    try
+                    {
+                        await _geyserProvisioning.EnsureGeyserSetupAsync(
+                            createdInstancePath,
+                            serverType,
+                            selectedVersion.Id,
+                            progress,
+                            message => Dispatcher.Invoke(() => TxtProgress.Text = message));
+
+                        // Persist the HasGeyser flag so the dashboard shows the Bedrock IP row
+                        metadata.HasGeyser = true;
+                        _instanceManager.SaveMetadata(metadata, createdInstancePath);
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        await CleanupFailedGeyserSetupAsync(createdInstancePath);
+                        metadata.HasGeyser = false;
+                        _instanceManager.SaveMetadata(metadata, createdInstancePath);
+
+                        MessageBox.Show(
+                            "Cross-play Setup Failed\n\n" +
+                            $"{ex.Message}\n\n" +
+                            "Your server was created without cross-play. You can add it later from Server Settings.",
+                            "Cross-play Setup Failed",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning);
+                    }
                 }
 
                 if (!NavigateToDashboard())
@@ -437,6 +460,36 @@ namespace PocketMC.Desktop.Features.InstanceCreation
             {
                 _logger.LogWarning(cleanupEx, "Failed to clean up the partially created instance at {InstancePath}.", instancePath);
             }
+        }
+
+        private Task CleanupFailedGeyserSetupAsync(string instancePath)
+        {
+            try
+            {
+                foreach (string targetDir in new[] { "plugins", "mods" })
+                {
+                    string basePath = Path.Combine(instancePath, targetDir);
+                    if (!Directory.Exists(basePath))
+                    {
+                        continue;
+                    }
+
+                    foreach (string fileName in new[] { "Geyser.jar", "Floodgate.jar" })
+                    {
+                        string filePath = Path.Combine(basePath, fileName);
+                        if (File.Exists(filePath))
+                        {
+                            File.Delete(filePath);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to clean up Geyser/Floodgate artifacts in {InstancePath}.", instancePath);
+            }
+
+            return Task.CompletedTask;
         }
 
         private bool NavigateToDashboard()

--- a/PocketMC.Desktop/Features/Instances/Services/GeyserProvisioningService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/GeyserProvisioningService.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PocketMC.Desktop.Features.Marketplace;
-using PocketMC.Desktop.Features.Instances.Models;
 
 namespace PocketMC.Desktop.Features.Instances.Services;
 
@@ -25,75 +24,149 @@ public class GeyserProvisioningService
         _logger = logger;
     }
 
-    /// <summary>
-    /// Provisions Geyser and Floodgate for a given Java server instance.
-    /// Deliberately does NOT pre-write config.yml — Geyser auto-generates a correct
-    /// one on first run. A hand-crafted config risks schema mismatches with the
-    /// installed Geyser build and will break plugin startup.
-    /// 
-    /// Connection info after first server run:
-    ///   - Bedrock clients connect on the SAME IP as Java, port 19132 (UDP)
-    ///   - Config lives in: plugins/Geyser-Spigot/config.yml  
-    /// </summary>
     public async Task EnsureGeyserSetupAsync(
         string instancePath,
         string serverType,
         string minecraftVersion,
         IProgress<DownloadProgress>? progress = null,
+        Action<string>? onProgress = null,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            string platform = serverType.ToLowerInvariant() switch
+            if (serverType.StartsWith("Vanilla", StringComparison.OrdinalIgnoreCase))
             {
-                "paper" or "spigot" => "spigot",  // Geyser calls it "spigot" for both Paper + Spigot
-                "fabric"            => "fabric",
-                "forge"             => "fabric",   // Forge uses the Fabric/NeoForge variant
-                _                   => "spigot"
-            };
+                throw new InvalidOperationException("Geyser requires Paper, Fabric, or Forge. Vanilla is not supported.");
+            }
 
-            string targetDir = platform == "fabric" ? "mods" : "plugins";
+            if (serverType.StartsWith("Bedrock", StringComparison.OrdinalIgnoreCase) ||
+                serverType.StartsWith("Pocketmine", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Bedrock and PocketMine servers do not need Geyser.");
+            }
+
+            string loader = ResolveLoader(serverType, minecraftVersion);
+            string targetDir = ResolveTargetDirectory(loader);
             string dirPath = Path.Combine(instancePath, targetDir);
             Directory.CreateDirectory(dirPath);
 
-            string geyserUrl = $"https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/{platform}";
-            string? floodgateUrl = null;
-
-            if (platform == "fabric")
+            onProgress?.Invoke($"Checking Geyser compatibility for {serverType} {minecraftVersion}...");
+            var geyserVersion = await _modrinth.GetLatestVersionAsync("geyser", minecraftVersion, loader);
+            if (geyserVersion == null)
             {
-                // GeyserMC Build API has removed Fabric versions of Floodgate (moved to Modrinth).
-                _logger.LogInformation("Fetching latest Floodgate ({Platform}) from Modrinth for MC {MinecraftVersion}...", platform, minecraftVersion);
-                var version = await _modrinth.GetLatestVersionAsync("floodgate", minecraftVersion, "fabric");
-                floodgateUrl = version?.Files.FirstOrDefault(f => f.IsPrimary)?.Url ?? version?.Files.FirstOrDefault()?.Url;
+                throw new InvalidOperationException(
+                    $"Geyser does not currently support Minecraft {minecraftVersion} on {serverType}. " +
+                    "Check https://modrinth.com/mod/geyser for supported versions.");
+            }
 
-                if (string.IsNullOrEmpty(floodgateUrl))
-                {
-                    _logger.LogWarning("Could not find Floodgate for Fabric on Modrinth. Falling back to GeyserMC API (likely to fail).");
-                    floodgateUrl = $"https://download.geysermc.org/v2/projects/floodgate/versions/latest/builds/latest/downloads/{platform}";
-                }
+            onProgress?.Invoke($"Downloading Geyser ({loader})...");
+            string geyserPath = Path.Combine(dirPath, "Geyser.jar");
+            await DownloadPrimaryFileAsync(geyserVersion, geyserPath, progress, cancellationToken);
+
+            onProgress?.Invoke("Checking Floodgate compatibility...");
+            var floodgateVersion = await _modrinth.GetLatestVersionAsync("floodgate", minecraftVersion, loader);
+            if (floodgateVersion == null)
+            {
+                _logger.LogWarning("Floodgate not found for {ServerType} {McVersion}. Installing Geyser only.", serverType, minecraftVersion);
+                onProgress?.Invoke($"Warning: Floodgate not available for {serverType} {minecraftVersion}. Geyser only.");
+                onProgress?.Invoke("Warning: Floodgate not available — Geyser only.");
             }
             else
             {
-                floodgateUrl = $"https://download.geysermc.org/v2/projects/floodgate/versions/latest/builds/latest/downloads/{platform}";
+                onProgress?.Invoke($"Downloading Floodgate ({loader})...");
+                string floodgatePath = Path.Combine(dirPath, "Floodgate.jar");
+                await DownloadPrimaryFileAsync(floodgateVersion, floodgatePath, progress, cancellationToken);
             }
 
-            string geyserPath    = Path.Combine(dirPath, "Geyser.jar");
-            string floodgatePath = Path.Combine(dirPath, "Floodgate.jar");
-
-            _logger.LogInformation("Downloading Geyser ({Platform})...", platform);
-            await _downloader.DownloadFileAsync(geyserUrl, geyserPath, null, progress, cancellationToken);
-
-            _logger.LogInformation("Downloading Floodgate from {Url}...", floodgateUrl);
-            await _downloader.DownloadFileAsync(floodgateUrl, floodgatePath, null, progress, cancellationToken);
-
-            // Write a README so users know how to connect Bedrock clients
             WriteConnectGuide(instancePath, targetDir);
+            onProgress?.Invoke("Cross-play setup complete.");
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to provision Geyser and Floodgate for {ServerType}.", serverType);
-            throw;
+            _logger.LogError(ex, "Failed to provision Geyser and Floodgate for {ServerType} {McVersion}.", serverType, minecraftVersion);
+            throw new InvalidOperationException(
+                $"Cross-play setup failed for {serverType} {minecraftVersion}. Try again later or install Geyser manually.", ex);
         }
+    }
+
+    private async Task DownloadPrimaryFileAsync(
+        ModrinthVersion version,
+        string destinationPath,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var file = version.Files.FirstOrDefault(f => f.IsPrimary) ?? version.Files.FirstOrDefault();
+        if (file == null)
+        {
+            throw new InvalidOperationException("Modrinth returned a version with no downloadable files.");
+        }
+
+        await _downloader.DownloadFileAsync(file.Url, destinationPath, null, progress, cancellationToken);
+    }
+
+    private static string ResolveLoader(string serverType, string minecraftVersion)
+    {
+        if (serverType.Equals("Paper", StringComparison.OrdinalIgnoreCase) ||
+            serverType.Equals("Spigot", StringComparison.OrdinalIgnoreCase))
+        {
+            return "spigot";
+        }
+
+        if (serverType.Equals("Fabric", StringComparison.OrdinalIgnoreCase))
+        {
+            return "fabric";
+        }
+
+        if (serverType.Equals("Forge", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsAtLeastMinecraftVersion(minecraftVersion, 1, 20, 5) ? "neoforge" : "forge";
+        }
+
+        return "spigot";
+    }
+
+    private static string ResolveTargetDirectory(string loader)
+    {
+        return loader switch
+        {
+            "fabric" or "forge" or "neoforge" => "mods",
+            _ => "plugins"
+        };
+    }
+
+    private static bool IsAtLeastMinecraftVersion(string minecraftVersion, int major, int minor, int patch)
+    {
+        if (string.IsNullOrWhiteSpace(minecraftVersion))
+        {
+            return false;
+        }
+
+        string normalized = minecraftVersion.Split('-', 2)[0];
+        string[] parts = normalized.Split('.');
+
+        int vMajor = parts.Length > 0 && int.TryParse(parts[0], out int parsedMajor) ? parsedMajor : 0;
+        int vMinor = parts.Length > 1 && int.TryParse(parts[1], out int parsedMinor) ? parsedMinor : 0;
+        int vPatch = parts.Length > 2 && int.TryParse(parts[2], out int parsedPatch) ? parsedPatch : 0;
+
+        if (vMajor != major)
+        {
+            return vMajor > major;
+        }
+
+        if (vMinor != minor)
+        {
+            return vMinor > minor;
+        }
+
+        return vPatch >= patch;
     }
 
     private void WriteConnectGuide(string instancePath, string targetDir)
@@ -101,7 +174,10 @@ public class GeyserProvisioningService
         try
         {
             string guidePath = Path.Combine(instancePath, "BEDROCK-CONNECT.txt");
-            if (File.Exists(guidePath)) return;
+            if (File.Exists(guidePath))
+            {
+                return;
+            }
 
             File.WriteAllText(guidePath,
                 "=== Bedrock Cross-Play (Geyser + Floodgate) ===\n\n" +


### PR DESCRIPTION
### Motivation

- Replace direct GeyserMC download URLs with Modrinth queries so installs respect server type and the selected Minecraft version.
- Ensure the installer selects the correct loader variant (spigot/fabric/forge/neoforge) and places artifacts in the appropriate folder (plugins/mods).
- Provide clear compatibility feedback to the user and avoid hard-failing the entire instance when Floodgate is unavailable.

### Description

- Rewrote `GeyserProvisioningService` to use `ModrinthService.GetLatestVersionAsync(slug, minecraftVersion, loader)` for both `geyser` and `floodgate`, passing the real `minecraftVersion` and mapped `loader` string.
- Implemented loader mapping: `Paper`/`Spigot` → `spigot`, `Fabric` → `fabric`, `Forge` → `neoforge` if MC ≥ `1.20.5` else `forge`, with `spigot` as a safe default.
- Target directory mapping added: `fabric`/`forge`/`neoforge` → `mods`, `spigot` → `plugins`.
- Downloads now select the Modrinth version's primary file (`Files.FirstOrDefault(f => f.IsPrimary)`) or the first file and call the existing `DownloaderService.DownloadFileAsync` to fetch the file.
- Added defensive server-type checks that throw `InvalidOperationException` for unsupported combinations (Vanilla, Bedrock, PocketMine) and explicit handling when Modrinth returns `null`:
  - Geyser `null` → throw an `InvalidOperationException` with a user-friendly message.
  - Floodgate `null` → log a warning and report progress messages but continue (install Geyser only).
- Wrapped the method to surface a clean `InvalidOperationException` message on unexpected failures and preserved cancellation handling.
- Added step-level progress messages via an `onProgress` callback (compatibility checks, download starts, Floodgate warning, completion).
- Kept constructor signature the same (`DownloaderService`, `ModrinthService`, `ILogger`) and removed direct `HttpClient` usage.
- Updated `NewInstancePage.xaml.cs` `BtnCreate` flow to pass a message callback into `EnsureGeyserSetupAsync`, catch `InvalidOperationException` from cross-play setup, remove only Geyser/Floodgate artifacts (not the entire instance), set `metadata.HasGeyser = false`, persist metadata, and show a friendly dialog to the user.

### Testing

- Attempted to build the desktop project with `dotnet build PocketMC.Desktop/PocketMC.Desktop.csproj -v minimal`, but the `dotnet` SDK is not available in the environment (`/bin/bash: dotnet: command not found`), so no compile was performed.
- No automated unit/integration tests were run as part of this change due to the unavailable SDK; runtime behavior should be validated in an environment with the .NET SDK installed.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34e5ad014833381c44392c465b387)