### PR TITLE
Improve Geyser provisioning (Modrinth support, cleanup, error handling) and bump version to 1.4.2

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -17,7 +17,7 @@ jobs:
       DOTNET_VERSION: "8.0.x"
       RUNTIME: win-x64
       APP_ID: PocketMC
-      VERSION: 1.4.1   # <-- single source of truth
+      VERSION: 1.4.2   # <-- single source of truth
 
     steps:
       - uses: actions/checkout@v4

--- a/PocketMC.Desktop/Features/InstanceCreation/NewInstancePage.xaml.cs
+++ b/PocketMC.Desktop/Features/InstanceCreation/NewInstancePage.xaml.cs
@@ -344,11 +344,33 @@ namespace PocketMC.Desktop.Features.InstanceCreation
                 if (ChkEnableGeyser.IsChecked == true && createdInstancePath != null)
                 {
                     TxtProgress.Text = "Setting up Geyser cross-play...";
-                    await _geyserProvisioning.EnsureGeyserSetupAsync(createdInstancePath, serverType, selectedVersion.Id, progress);
+                    try
+                    {
+                        await _geyserProvisioning.EnsureGeyserSetupAsync(
+                            createdInstancePath,
+                            serverType,
+                            selectedVersion.Id,
+                            progress,
+                            message => Dispatcher.Invoke(() => TxtProgress.Text = message));
 
-                    // Persist the HasGeyser flag so the dashboard shows the Bedrock IP row
-                    metadata.HasGeyser = true;
-                    _instanceManager.SaveMetadata(metadata, createdInstancePath);
+                        // Persist the HasGeyser flag so the dashboard shows the Bedrock IP row
+                        metadata.HasGeyser = true;
+                        _instanceManager.SaveMetadata(metadata, createdInstancePath);
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        await CleanupFailedGeyserSetupAsync(createdInstancePath);
+                        metadata.HasGeyser = false;
+                        _instanceManager.SaveMetadata(metadata, createdInstancePath);
+
+                        MessageBox.Show(
+                            $"Cross-play Setup Failed\n\n{ex.Message}\n\nYour server was created without cross-play. You can add it later from Server Settings.",
+                            "Cross-play Setup Failed",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning);
+
+                        _logger.LogWarning(ex, "Cross-play setup failed for instance {InstanceName}. Continuing without Geyser.", TxtName.Text);
+                    }
                 }
 
                 if (!NavigateToDashboard())
@@ -436,6 +458,35 @@ namespace PocketMC.Desktop.Features.InstanceCreation
             catch (Exception cleanupEx)
             {
                 _logger.LogWarning(cleanupEx, "Failed to clean up the partially created instance at {InstancePath}.", instancePath);
+            }
+        }
+
+        private static Task CleanupFailedGeyserSetupAsync(string instancePath)
+        {
+            string pluginsPath = Path.Combine(instancePath, "plugins");
+            string modsPath = Path.Combine(instancePath, "mods");
+
+            TryDeleteFile(Path.Combine(pluginsPath, "Geyser.jar"));
+            TryDeleteFile(Path.Combine(pluginsPath, "Floodgate.jar"));
+            TryDeleteFile(Path.Combine(modsPath, "Geyser.jar"));
+            TryDeleteFile(Path.Combine(modsPath, "Floodgate.jar"));
+            TryDeleteFile(Path.Combine(instancePath, "BEDROCK-CONNECT.txt"));
+
+            return Task.CompletedTask;
+        }
+
+        private static void TryDeleteFile(string filePath)
+        {
+            try
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup only.
             }
         }
 

--- a/PocketMC.Desktop/Features/Instances/Services/GeyserProvisioningService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/GeyserProvisioningService.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PocketMC.Desktop.Features.Marketplace;
-using PocketMC.Desktop.Features.Instances.Models;
 
 namespace PocketMC.Desktop.Features.Instances.Services;
 
@@ -25,75 +24,154 @@ public class GeyserProvisioningService
         _logger = logger;
     }
 
-    /// <summary>
-    /// Provisions Geyser and Floodgate for a given Java server instance.
-    /// Deliberately does NOT pre-write config.yml — Geyser auto-generates a correct
-    /// one on first run. A hand-crafted config risks schema mismatches with the
-    /// installed Geyser build and will break plugin startup.
-    /// 
-    /// Connection info after first server run:
-    ///   - Bedrock clients connect on the SAME IP as Java, port 19132 (UDP)
-    ///   - Config lives in: plugins/Geyser-Spigot/config.yml  
-    /// </summary>
     public async Task EnsureGeyserSetupAsync(
         string instancePath,
         string serverType,
         string minecraftVersion,
         IProgress<DownloadProgress>? progress = null,
+        Action<string>? onProgress = null,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            string platform = serverType.ToLowerInvariant() switch
+            if (serverType.StartsWith("Vanilla", StringComparison.OrdinalIgnoreCase))
             {
-                "paper" or "spigot" => "spigot",  // Geyser calls it "spigot" for both Paper + Spigot
-                "fabric"            => "fabric",
-                "forge"             => "fabric",   // Forge uses the Fabric/NeoForge variant
-                _                   => "spigot"
-            };
+                throw new InvalidOperationException("Geyser requires Paper, Fabric, or Forge. Vanilla is not supported.");
+            }
 
-            string targetDir = platform == "fabric" ? "mods" : "plugins";
+            if (serverType.StartsWith("Bedrock", StringComparison.OrdinalIgnoreCase) ||
+                serverType.StartsWith("Pocketmine", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Bedrock and PocketMine servers do not need Geyser.");
+            }
+
+            string loader = ResolveLoader(serverType, minecraftVersion);
+            string targetDir = ResolveTargetDirectory(loader);
             string dirPath = Path.Combine(instancePath, targetDir);
             Directory.CreateDirectory(dirPath);
 
-            string geyserUrl = $"https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/{platform}";
-            string? floodgateUrl = null;
+            onProgress?.Invoke($"Checking Geyser compatibility for {serverType} {minecraftVersion}...");
+            _logger.LogInformation("Checking Geyser compatibility for {ServerType} {MinecraftVersion} with loader {Loader}.", serverType, minecraftVersion, loader);
 
-            if (platform == "fabric")
+            var geyserVersion = await _modrinth.GetLatestVersionAsync("geyser", minecraftVersion, loader);
+            if (geyserVersion == null)
             {
-                // GeyserMC Build API has removed Fabric versions of Floodgate (moved to Modrinth).
-                _logger.LogInformation("Fetching latest Floodgate ({Platform}) from Modrinth for MC {MinecraftVersion}...", platform, minecraftVersion);
-                var version = await _modrinth.GetLatestVersionAsync("floodgate", minecraftVersion, "fabric");
-                floodgateUrl = version?.Files.FirstOrDefault(f => f.IsPrimary)?.Url ?? version?.Files.FirstOrDefault()?.Url;
-
-                if (string.IsNullOrEmpty(floodgateUrl))
-                {
-                    _logger.LogWarning("Could not find Floodgate for Fabric on Modrinth. Falling back to GeyserMC API (likely to fail).");
-                    floodgateUrl = $"https://download.geysermc.org/v2/projects/floodgate/versions/latest/builds/latest/downloads/{platform}";
-                }
-            }
-            else
-            {
-                floodgateUrl = $"https://download.geysermc.org/v2/projects/floodgate/versions/latest/builds/latest/downloads/{platform}";
+                throw new InvalidOperationException(
+                    $"Geyser does not currently support Minecraft {minecraftVersion} on {serverType}. " +
+                    "Check https://modrinth.com/mod/geyser for supported versions.");
             }
 
-            string geyserPath    = Path.Combine(dirPath, "Geyser.jar");
-            string floodgatePath = Path.Combine(dirPath, "Floodgate.jar");
+            onProgress?.Invoke($"Downloading Geyser ({loader})...");
+            _logger.LogInformation("Downloading Geyser ({Loader}) for MC {MinecraftVersion}.", loader, minecraftVersion);
+            await DownloadVersionAsync(geyserVersion, Path.Combine(dirPath, "Geyser.jar"), progress, cancellationToken);
 
-            _logger.LogInformation("Downloading Geyser ({Platform})...", platform);
-            await _downloader.DownloadFileAsync(geyserUrl, geyserPath, null, progress, cancellationToken);
+            onProgress?.Invoke("Checking Floodgate compatibility...");
+            _logger.LogInformation("Checking Floodgate compatibility for {ServerType} {MinecraftVersion} with loader {Loader}.", serverType, minecraftVersion, loader);
 
-            _logger.LogInformation("Downloading Floodgate from {Url}...", floodgateUrl);
-            await _downloader.DownloadFileAsync(floodgateUrl, floodgatePath, null, progress, cancellationToken);
+            var floodgateVersion = await _modrinth.GetLatestVersionAsync("floodgate", minecraftVersion, loader);
+            if (floodgateVersion == null)
+            {
+                _logger.LogWarning("Floodgate not found for {ServerType} {McVersion}. Installing Geyser only.", serverType, minecraftVersion);
+                onProgress?.Invoke("Warning: Floodgate not available — Geyser only.");
+                onProgress?.Invoke("Cross-play setup complete.");
+                WriteConnectGuide(instancePath, targetDir);
+                return;
+            }
 
-            // Write a README so users know how to connect Bedrock clients
+            onProgress?.Invoke($"Downloading Floodgate ({loader})...");
+            _logger.LogInformation("Downloading Floodgate ({Loader}) for MC {MinecraftVersion}.", loader, minecraftVersion);
+            await DownloadVersionAsync(floodgateVersion, Path.Combine(dirPath, "Floodgate.jar"), progress, cancellationToken);
+
             WriteConnectGuide(instancePath, targetDir);
+            onProgress?.Invoke("Cross-play setup complete.");
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to provision Geyser and Floodgate for {ServerType}.", serverType);
-            throw;
+            _logger.LogError(ex, "Failed to provision Geyser and Floodgate for {ServerType} {MinecraftVersion}.", serverType, minecraftVersion);
+            throw new InvalidOperationException(
+                $"Unable to complete cross-play setup for {serverType} {minecraftVersion}. Please try again later or install Geyser manually.",
+                ex);
         }
+    }
+
+    private async Task DownloadVersionAsync(
+        ModrinthVersion version,
+        string destinationPath,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var file = version.Files.FirstOrDefault(f => f.IsPrimary) ?? version.Files.FirstOrDefault();
+        if (file == null)
+        {
+            throw new InvalidOperationException("Modrinth returned a version with no downloadable files.");
+        }
+
+        await _downloader.DownloadFileAsync(file.Url, destinationPath, null, progress, cancellationToken);
+    }
+
+    private static string ResolveLoader(string serverType, string minecraftVersion)
+    {
+        if (serverType.Equals("Paper", StringComparison.OrdinalIgnoreCase) ||
+            serverType.Equals("Spigot", StringComparison.OrdinalIgnoreCase))
+        {
+            return "spigot";
+        }
+
+        if (serverType.Equals("Fabric", StringComparison.OrdinalIgnoreCase))
+        {
+            return "fabric";
+        }
+
+        if (serverType.Equals("Forge", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsAtLeastVersion(minecraftVersion, 1, 20, 5) ? "neoforge" : "forge";
+        }
+
+        return "spigot";
+    }
+
+    private static string ResolveTargetDirectory(string loader)
+    {
+        return loader switch
+        {
+            "fabric" or "forge" or "neoforge" => "mods",
+            _ => "plugins"
+        };
+    }
+
+    private static bool IsAtLeastVersion(string version, int major, int minor, int patch)
+    {
+        var raw = version.Split('-', StringSplitOptions.RemoveEmptyEntries)[0];
+        var parts = raw.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+        if (parts.Length < 2 ||
+            !int.TryParse(parts[0], out var inputMajor) ||
+            !int.TryParse(parts[1], out var inputMinor))
+        {
+            return false;
+        }
+
+        var inputPatch = 0;
+        if (parts.Length > 2)
+        {
+            _ = int.TryParse(parts[2], out inputPatch);
+        }
+
+        if (inputMajor != major)
+        {
+            return inputMajor > major;
+        }
+
+        if (inputMinor != minor)
+        {
+            return inputMinor > minor;
+        }
+
+        return inputPatch >= patch;
     }
 
     private void WriteConnectGuide(string instancePath, string targetDir)

--- a/PocketMC.Desktop/PocketMC.Desktop.csproj
+++ b/PocketMC.Desktop/PocketMC.Desktop.csproj
@@ -9,9 +9,9 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <StartupObject>PocketMC.Desktop.Program</StartupObject>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
-    <Version>1.4.1</Version>
-    <AssemblyVersion>1.4.1.0</AssemblyVersion>
-    <FileVersion>1.4.1.0</FileVersion>
+    <Version>1.4.2</Version>
+    <AssemblyVersion>1.4.2.0</AssemblyVersion>
+    <FileVersion>1.4.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Make Geyser/Floodgate provisioning more reliable and user-friendly by using Modrinth for compatibility checks and downloads and by adding robust error handling and cleanup.
- Surface progress messages to the UI during cross-play setup and ensure instance metadata reflects whether Geyser was successfully installed.
- Bump application version to keep the build pipeline and assembly info consistent.

### Description
- Reworked `GeyserProvisioningService` to use Modrinth lookups and `DownloadVersionAsync` instead of hard-coded GeyserMC URLs, added `onProgress` callbacks, and improved logging and error translation into `InvalidOperationException` for user-facing errors.
- Added loader resolution (`ResolveLoader`), target directory resolution (`ResolveTargetDirectory`), and version comparison helper (`IsAtLeastVersion`) to determine correct artifacts and paths for Paper/Spigot, Fabric, Forge, and NeoForge.
- Updated `NewInstancePage.xaml.cs` to invoke `EnsureGeyserSetupAsync` with a UI progress callback, persist `metadata.HasGeyser` on success, and catch failures to run a best-effort cleanup via `CleanupFailedGeyserSetupAsync` and show a warning to the user.
- Implemented `CleanupFailedGeyserSetupAsync` and `TryDeleteFile` helpers to remove partial Geyser/Floodgate artifacts and added best-effort handling so cleanup failures are ignored.
- Updated project and CI: bumped `Version`, `AssemblyVersion`, and `FileVersion` to `1.4.2` in `PocketMC.Desktop.csproj` and updated the `VERSION` env in `.github/workflows/production-build.yml`.

### Testing
- Ran `dotnet build PocketMC.Desktop.sln -c Debug` and `dotnet build PocketMC.Desktop.sln -c Release` as part of CI and both builds completed successfully.
- Executed `dotnet test PocketMC.Desktop.sln --no-build` and all automated tests passed.
- Verified basic end-to-end instance creation flow manually in the UI to confirm progress updates, metadata persistence, and cleanup behavior on simulated Geyser failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34e5ad014833381c44392c465b387)