### PR TITLE
Return null for Modrinth loader fallback and clarify version-not-found messages

### DIFF
--- a/PocketMC.Desktop/Features/Marketplace/ModrinthService.cs
+++ b/PocketMC.Desktop/Features/Marketplace/ModrinthService.cs
@@ -125,7 +125,7 @@ namespace PocketMC.Desktop.Features.Marketplace
                     var relaxedVersions = await _httpClient.GetFromJsonAsync<List<ModrinthVersion>>(relaxedUrl) ?? new();
                     var loaderMatch = relaxedVersions.Find(v => v.Loaders.Any(l => l.Equals(loader, StringComparison.OrdinalIgnoreCase)));
                     if (loaderMatch != null) return loaderMatch;
-                    return relaxedVersions.Count > 0 ? relaxedVersions[0] : null;
+                    return null;
                 }
 
                 return null;

--- a/PocketMC.Desktop/Features/Marketplace/PluginBrowserPage.xaml.cs
+++ b/PocketMC.Desktop/Features/Marketplace/PluginBrowserPage.xaml.cs
@@ -249,15 +249,16 @@ namespace PocketMC.Desktop.Features.Marketplace
 
                 if (version == null || version.Files.Count == 0)
                 {
+                    string mcVersionLabel = _mcVersion == "*" ? "any Minecraft version" : _mcVersion;
                     bool isModProject = _projectType.Contains("mod", StringComparison.OrdinalIgnoreCase);
                     if (isModProject && !string.IsNullOrWhiteSpace(_loader) && !isPoggit)
                     {
                         string loaderLabel = ToDisplayLoader(_loader);
-                        System.Windows.MessageBox.Show($"No compatible {loaderLabel} version found for Minecraft {_mcVersion}.", "Not Found", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        System.Windows.MessageBox.Show($"No compatible {loaderLabel} version found for {mcVersionLabel}.", "Not Found", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
                     else
                     {
-                        System.Windows.MessageBox.Show($"No compatible version found for Minecraft {_mcVersion}.", "Not Found", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        System.Windows.MessageBox.Show($"No compatible version found for {mcVersionLabel}.", "Not Found", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
                     btn.IsEnabled = true;
                     btn.Content = "Install";


### PR DESCRIPTION
### Motivation
- Prevent returning an unrelated Modrinth version when a loader filter doesn't match by removing a permissive fallback. 
- Make the user-facing "version not found" dialog clearer when the requested Minecraft version is a wildcard (`"*"`).

### Description
- In `ModrinthService` changed the relaxed fallback to return `null` instead of `relaxedVersions[0]` when no version matches the requested loader. 
- In `PluginBrowserPage.xaml.cs` added a `mcVersionLabel` (showing `"any Minecraft version"` for `"*"`) and updated the `MessageBox.Show` calls to use this label for clearer messaging. 
- No other behavioral changes were made to the download/install flow.

### Testing
- Built the solution with `dotnet build` and the build completed successfully. 
- Executed the existing test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5341b12d88333b39a5745dba64c27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined plugin and mod installation logic to prevent selection of incompatible versions. Improved warning messages now clearly distinguish between "any Minecraft version" compatibility and specific version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->