### PR TITLE
Fix startup port reservation race and partial-lease rollback

### DIFF
--- a/PocketMC.Desktop.Tests/AddonManifestTests.cs
+++ b/PocketMC.Desktop.Tests/AddonManifestTests.cs
@@ -1,0 +1,39 @@
+using PocketMC.Desktop.Features.Mods;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class AddonManifestTests : IDisposable
+{
+    private readonly string _addonsDir = Path.Combine(Path.GetTempPath(), "PocketMC.AddonManifestTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task SyncManifestAsync_ShouldRemoveDeletedFiles()
+    {
+        Directory.CreateDirectory(_addonsDir);
+        var manifest = new AddonManifest();
+
+        await manifest.SaveAsync(_addonsDir, new[]
+        {
+            new AddonManifestEntry
+            {
+                FileName = "mod-a.jar",
+                ProjectId = "mod-a",
+                Provider = "Modrinth",
+                VersionId = "",
+                InstalledAt = DateTime.MinValue
+            }
+        });
+
+        IReadOnlyList<AddonManifestEntry> synced = await manifest.SyncManifestAsync(_addonsDir);
+
+        Assert.Empty(synced);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_addonsDir))
+        {
+            Directory.Delete(_addonsDir, recursive: true);
+        }
+    }
+}

--- a/PocketMC.Desktop.Tests/BedrockAddonInstallerTests.cs
+++ b/PocketMC.Desktop.Tests/BedrockAddonInstallerTests.cs
@@ -1,0 +1,87 @@
+using System.IO.Compression;
+using Microsoft.Extensions.Logging.Abstractions;
+using PocketMC.Desktop.Features.Mods;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class BedrockAddonInstallerTests : IDisposable
+{
+    private readonly string _rootPath = Path.Combine(Path.GetTempPath(), "PocketMC.BedrockAddonTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task InstallAsync_UsesLevelNameWorldDirectory_WhenConfigured()
+    {
+        string serverDir = CreateServerDirectory("level-name=MyServer");
+        string addonArchive = CreateAddonArchive();
+        var installer = new BedrockAddonInstaller(NullLogger<BedrockAddonInstaller>.Instance);
+
+        await installer.InstallAsync(addonArchive, serverDir);
+
+        string configuredWorldJson = Path.Combine(serverDir, "worlds", "MyServer", "world_behavior_packs.json");
+        string defaultWorldJson = Path.Combine(serverDir, "worlds", "Bedrock level", "world_behavior_packs.json");
+
+        Assert.True(File.Exists(configuredWorldJson));
+        Assert.False(File.Exists(defaultWorldJson));
+    }
+
+    [Fact]
+    public async Task InstallAsync_UsesDefaultWorldDirectory_WhenLevelNameMissing()
+    {
+        string serverDir = CreateServerDirectory("# no level-name configured");
+        string addonArchive = CreateAddonArchive();
+        var installer = new BedrockAddonInstaller(NullLogger<BedrockAddonInstaller>.Instance);
+
+        await installer.InstallAsync(addonArchive, serverDir);
+
+        string defaultWorldJson = Path.Combine(serverDir, "worlds", "Bedrock level", "world_behavior_packs.json");
+        Assert.True(File.Exists(defaultWorldJson));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootPath))
+        {
+            Directory.Delete(_rootPath, recursive: true);
+        }
+    }
+
+    private string CreateServerDirectory(string serverPropertiesContent)
+    {
+        string serverDir = Path.Combine(_rootPath, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(serverDir);
+        File.WriteAllText(Path.Combine(serverDir, "server.properties"), serverPropertiesContent + Environment.NewLine);
+        return serverDir;
+    }
+
+    private string CreateAddonArchive()
+    {
+        string addonDir = Path.Combine(_rootPath, "addon-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(addonDir);
+        string packDir = Path.Combine(addonDir, "SamplePack");
+        Directory.CreateDirectory(packDir);
+
+        File.WriteAllText(
+            Path.Combine(packDir, "manifest.json"),
+            """
+            {
+              "format_version": 2,
+              "header": {
+                "name": "Sample Pack",
+                "uuid": "11111111-2222-3333-4444-555555555555",
+                "version": [1, 0, 0]
+              },
+              "modules": [
+                {
+                  "type": "data",
+                  "uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                  "version": [1, 0, 0]
+                }
+              ]
+            }
+            """);
+
+        string archivePath = Path.Combine(_rootPath, Guid.NewGuid().ToString("N") + ".mcpack");
+        ZipFile.CreateFromDirectory(addonDir, archivePath);
+        return archivePath;
+    }
+}

--- a/PocketMC.Desktop.Tests/ControlledNavigationStackTests.cs
+++ b/PocketMC.Desktop.Tests/ControlledNavigationStackTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using PocketMC.Desktop.Navigation;
 
 namespace PocketMC.Desktop.Tests;
@@ -157,6 +159,28 @@ public class ControlledNavigationStackTests
 
         Assert.True(first.Success);
         Assert.False(second.Success);
+        Assert.Empty(stack.Entries);
+    }
+
+    [Fact]
+    public void NavigateBack_WhenPreviousDetailIsOrphaned_DoesNotThrowAndHealsStack()
+    {
+        var stack = new ControlledNavigationStack();
+        FieldInfo? entriesField = typeof(ControlledNavigationStack).GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(entriesField);
+
+        var entries = (List<ControlledNavigationEntry>)entriesField!.GetValue(stack)!;
+        entries.Clear();
+        entries.Add(new ControlledNavigationEntry(
+            Guid.NewGuid().ToString("N"),
+            NavigationRouteKind.PluginBrowser,
+            NavigationBackTarget.PreviousDetail()));
+
+        ControlledBackNavigationResult result = stack.NavigateBack();
+
+        Assert.True(result.Success);
+        Assert.True(result.TargetsShellRoute);
+        Assert.Equal(NavigationRouteKind.Dashboard, result.TargetRoute);
         Assert.Empty(stack.Entries);
     }
 }

--- a/PocketMC.Desktop.Tests/DownloaderServiceTests.cs
+++ b/PocketMC.Desktop.Tests/DownloaderServiceTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using PocketMC.Desktop.Features.Instances.Services;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class DownloaderServiceTests : IDisposable
+{
+    private readonly string _rootPath = Path.Combine(Path.GetTempPath(), "PocketMC.DownloaderTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task DownloadFileAsync_WithoutExpectedHash_DoesNotResumeExistingPartial()
+    {
+        Directory.CreateDirectory(_rootPath);
+        string destinationPath = Path.Combine(_rootPath, "playit.exe");
+        string partialPath = destinationPath + ".partial";
+        await File.WriteAllTextAsync(partialPath, "stale-partial");
+
+        RangeHeaderValue? observedRange = null;
+        var service = new DownloaderService(
+            new TestHttpClientFactory(_ => new HttpClient(new DelegateHttpMessageHandler((request, _) =>
+            {
+                observedRange = request.Headers.Range;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes("fresh-binary"))
+                };
+            }))),
+            NullLogger<DownloaderService>.Instance);
+
+        await service.DownloadFileAsync("https://example.invalid/playit.exe", destinationPath, expectedHash: null);
+
+        Assert.Null(observedRange);
+        Assert.True(File.Exists(destinationPath));
+        Assert.Equal("fresh-binary", await File.ReadAllTextAsync(destinationPath));
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_WithExpectedHash_ResumesExistingPartial()
+    {
+        Directory.CreateDirectory(_rootPath);
+        string destinationPath = Path.Combine(_rootPath, "runtime.zip");
+        string partialPath = destinationPath + ".partial";
+        await File.WriteAllTextAsync(partialPath, "abc");
+
+        string expectedContent = "abcdef";
+        string expectedHash = ComputeSha256Hex(expectedContent);
+        RangeHeaderValue? observedRange = null;
+
+        var service = new DownloaderService(
+            new TestHttpClientFactory(_ => new HttpClient(new DelegateHttpMessageHandler((request, _) =>
+            {
+                observedRange = request.Headers.Range;
+                var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+                {
+                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes("def"))
+                };
+
+                response.Content.Headers.ContentRange = new ContentRangeHeaderValue(3, 5, 6);
+                return response;
+            }))),
+            NullLogger<DownloaderService>.Instance);
+
+        await service.DownloadFileAsync("https://example.invalid/runtime.zip", destinationPath, expectedHash);
+
+        Assert.NotNull(observedRange);
+        Assert.Equal(3, observedRange!.Ranges.Single().From);
+        Assert.True(File.Exists(destinationPath));
+        Assert.Equal(expectedContent, await File.ReadAllTextAsync(destinationPath));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootPath))
+        {
+            Directory.Delete(_rootPath, recursive: true);
+        }
+    }
+
+    private static string ComputeSha256Hex(string content)
+    {
+        byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(content));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/PocketMC.Desktop.Tests/DownloaderServiceTests.cs
+++ b/PocketMC.Desktop.Tests/DownloaderServiceTests.cs
@@ -72,6 +72,20 @@ public sealed class DownloaderServiceTests : IDisposable
         Assert.Equal(expectedContent, await File.ReadAllTextAsync(destinationPath));
     }
 
+    [Fact]
+    public void CanResumePlayitDownload_WhenHashIsUnpinned_ReturnsFalse()
+    {
+        var service = new DownloaderService(
+            new TestHttpClientFactory(_ => new HttpClient(new DelegateHttpMessageHandler((_, _) =>
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(Array.Empty<byte>())
+                }))),
+            NullLogger<DownloaderService>.Instance);
+
+        Assert.False(service.CanResumePlayitDownload());
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_rootPath))

--- a/PocketMC.Desktop.Tests/PocketmineProviderTests.cs
+++ b/PocketMC.Desktop.Tests/PocketmineProviderTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using PocketMC.Desktop.Features.Instances.Providers;
+using PocketMC.Desktop.Features.Instances.Services;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class PocketmineProviderTests
+{
+    [Fact]
+    public async Task GetAvailableVersionsAsync_UsesCachedReleases()
+    {
+        int requestCount = 0;
+        using var httpClient = new HttpClient(new DelegateHttpMessageHandler((_, _) =>
+        {
+            requestCount++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """[{"tag_name":"5.0.0","prerelease":false,"assets":[{"name":"PocketMine-MP.phar","browser_download_url":"https://example.invalid/PocketMine-MP.phar"}]}]""",
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        }));
+
+        var downloader = new DownloaderService(
+            new TestHttpClientFactory(_ => new HttpClient(new DelegateHttpMessageHandler((_, _) =>
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(Array.Empty<byte>()) }))),
+            NullLogger<DownloaderService>.Instance);
+
+        var provider = new PocketmineProvider(httpClient, downloader, NullLogger<PocketmineProvider>.Instance);
+
+        var first = await provider.GetAvailableVersionsAsync();
+        var second = await provider.GetAvailableVersionsAsync();
+
+        Assert.Single(first);
+        Assert.Single(second);
+        Assert.Equal(1, requestCount);
+    }
+
+    [Fact]
+    public async Task DownloadSoftwareAsync_WhenRateLimited_ThrowsFriendlyMessage()
+    {
+        using var httpClient = new HttpClient(new DelegateHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent("""{"message":"API rate limit exceeded"}""", Encoding.UTF8, "application/json")
+            };
+
+            long reset = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds();
+            response.Headers.TryAddWithoutValidation("X-RateLimit-Reset", reset.ToString());
+            return response;
+        }));
+
+        var downloader = new DownloaderService(
+            new TestHttpClientFactory(_ => new HttpClient(new DelegateHttpMessageHandler((_, _) =>
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(Array.Empty<byte>()) }))),
+            NullLogger<DownloaderService>.Instance);
+
+        var provider = new PocketmineProvider(httpClient, downloader, NullLogger<PocketmineProvider>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            provider.DownloadSoftwareAsync("5.0.0", Path.Combine(Path.GetTempPath(), "pmmp-test.phar")));
+
+        Assert.Contains("rate limit", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Try again", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/PocketMC.Desktop.Tests/ServerLifecycleServiceTests.cs
+++ b/PocketMC.Desktop.Tests/ServerLifecycleServiceTests.cs
@@ -70,4 +70,52 @@ public sealed class ServerLifecycleServiceTests
         Assert.Empty(leaseRegistry.GetLeasesForInstance(metadata.Id));
         Assert.Null(workspace.AppState.GetTunnelAddress(metadata.Id));
     }
+
+    [Fact]
+    public async Task StartAsync_WhenLeaseConflictOccursAfterPartialReservation_RollsBackAlreadyReservedLeases()
+    {
+        using var workspace = new PortReliabilityTestWorkspace();
+        ServerProcessManager processManager = workspace.CreateServerProcessManager();
+        PortPreflightService preflightService = workspace.CreatePortPreflightService(processManager);
+        PortProbeService probeService = workspace.CreatePortProbeService();
+        PortLeaseRegistry leaseRegistry = workspace.CreatePortLeaseRegistry();
+        PortRecoveryService recoveryService = workspace.CreatePortRecoveryService(probeService, leaseRegistry);
+        ServerLifecycleService lifecycleService = workspace.CreateServerLifecycleService(
+            processManager,
+            preflightService,
+            probeService,
+            leaseRegistry,
+            recoveryService);
+
+        int javaPort = workspace.GetAvailableTcpPort();
+        int geyserPort = workspace.GetAvailableUdpPort();
+        var metadata = workspace.CreateInstance("Java + Geyser Conflict", serverType: "Paper");
+        metadata.HasGeyser = true;
+        metadata.GeyserBedrockPort = geyserPort;
+        workspace.WriteServerProperties(metadata.Id, $"server-port={javaPort}");
+
+        string instancePath = workspace.GetInstancePath(metadata.Id);
+        PortCheckRequest geyserRequest = preflightService.BuildRequests(metadata, instancePath)
+            .Single(request => request.BindingRole == PortBindingRole.GeyserBedrock);
+
+        var competingLease = new PortLease(
+            geyserRequest.Port,
+            geyserRequest.Protocol,
+            geyserRequest.IpMode,
+            Guid.NewGuid(),
+            "Competing Instance",
+            workspace.RootPath,
+            geyserRequest.BindAddress);
+
+        Assert.True(leaseRegistry.TryReserve(competingLease, out _));
+
+        await Assert.ThrowsAsync<PortReliabilityException>(() => lifecycleService.StartAsync(metadata));
+
+        Assert.Empty(leaseRegistry.GetLeasesForInstance(metadata.Id));
+        Assert.NotNull(leaseRegistry.FindHolder(
+            competingLease.Port,
+            competingLease.Protocol,
+            competingLease.IpMode,
+            competingLease.BindAddress));
+    }
 }

--- a/PocketMC.Desktop/Features/Instances/Backups/BackupService.cs
+++ b/PocketMC.Desktop/Features/Instances/Backups/BackupService.cs
@@ -178,14 +178,9 @@ public class BackupService
             {
                 try
                 {
-                    // Try RCON first
-                    if (!_configService.TryGetProperty(serverDir, "enable-rcon", out var rconEnabled) || rconEnabled != "true")
+                    bool restoredViaRcon = await TrySendSaveOnViaRconAsync(serverDir, onProgress);
+                    if (!restoredViaRcon)
                     {
-                        await process.WriteInputAsync("save-on");
-                    }
-                    else
-                    {
-                        // We could use RCON here too, but save-on is safe via console
                         await process.WriteInputAsync("save-on");
                     }
                 }
@@ -237,6 +232,36 @@ public class BackupService
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "RCON sync failed.");
+            return false;
+        }
+    }
+
+    private async Task<bool> TrySendSaveOnViaRconAsync(string serverDir, Action<string>? onProgress)
+    {
+        try
+        {
+            if (!_configService.TryGetProperty(serverDir, "enable-rcon", out var rconEnabled) || rconEnabled != "true")
+            {
+                return false;
+            }
+
+            _configService.TryGetProperty(serverDir, "rcon.port", out var portStr);
+            _configService.TryGetProperty(serverDir, "rcon.password", out var password);
+
+            if (string.IsNullOrEmpty(password) || !int.TryParse(portStr ?? "25575", out int port))
+            {
+                return false;
+            }
+
+            onProgress?.Invoke("Restoring auto-save via RCON...");
+            using var rcon = new RconClient("127.0.0.1", port, password);
+            await rcon.ConnectAsync();
+            await rcon.ExecuteCommandAsync("save-on");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "RCON save-on failed; falling back to console input.");
             return false;
         }
     }

--- a/PocketMC.Desktop/Features/Instances/Models/ServerProcess.cs
+++ b/PocketMC.Desktop/Features/Instances/Models/ServerProcess.cs
@@ -35,6 +35,7 @@ public class ServerProcess : IDisposable
     private bool _disposed;
     private volatile bool _intentionalStop;
     private readonly ConcurrentDictionary<TaskCompletionSource<bool>, Regex> _outputWaiters = new();
+    private readonly object _sessionLogSync = new();
     private StreamWriter? _sessionLogWriter;
     private const int MAX_BUFFER_LINES = 5000;
 
@@ -62,16 +63,31 @@ public class ServerProcess : IDisposable
 
     public async Task StartAsync(InstanceMetadata meta, string workingDir, string appRootPath)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ServerProcess));
+
         if (State != ServerState.Stopped && State != ServerState.Crashed)
             throw new InvalidOperationException($"Cannot start server — current state is {State}.");
 
         WorkingDirectory = workingDir;
-        InitializeSessionLog(workingDir);
         CleanSessionLock(workingDir);
 
         try
         {
             var psi = await _launchConfigurator.ConfigureAsync(meta, workingDir, appRootPath, l => AppendOutput(l));
+            StreamWriter? sessionLogWriter = CreateSessionLogWriter(workingDir);
+
+            lock (_sessionLogSync)
+            {
+                if (_disposed)
+                {
+                    sessionLogWriter?.Dispose();
+                    throw new ObjectDisposedException(nameof(ServerProcess));
+                }
+
+                _sessionLogWriter?.Dispose();
+                _sessionLogWriter = sessionLogWriter;
+            }
 
             SetState(ServerState.Starting);
             _intentionalStop = false;
@@ -89,13 +105,12 @@ public class ServerProcess : IDisposable
         }
         catch
         {
-            _sessionLogWriter?.Dispose();
-            _sessionLogWriter = null;
+            CloseSessionLogWriter();
             throw;
         }
     }
 
-    private void InitializeSessionLog(string workingDir)
+    private StreamWriter? CreateSessionLogWriter(string workingDir)
     {
         try
         {
@@ -103,9 +118,13 @@ public class ServerProcess : IDisposable
             Directory.CreateDirectory(logDir);
             string sessionLogPath = Path.Combine(logDir, "pocketmc-session.log");
             var stream = new FileStream(sessionLogPath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
-            _sessionLogWriter = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
+            return new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
         }
-        catch (Exception ex) { _logger.LogWarning(ex, "Failed to initialize session log."); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to initialize session log.");
+            return null;
+        }
     }
 
     private void CleanSessionLock(string workingDir)
@@ -226,7 +245,13 @@ public class ServerProcess : IDisposable
         OutputBuffer.Enqueue(sanitizedLine);
         if (OutputBuffer.Count > MAX_BUFFER_LINES) OutputBuffer.TryDequeue(out _);
 
-        try { _sessionLogWriter?.WriteLine(sanitizedLine); }
+        StreamWriter? logWriter;
+        lock (_sessionLogSync)
+        {
+            logWriter = _sessionLogWriter;
+        }
+
+        try { logWriter?.WriteLine(sanitizedLine); }
         catch { }
 
         if (isError) OnErrorLine?.Invoke(sanitizedLine);
@@ -288,10 +313,18 @@ public class ServerProcess : IDisposable
         if (!_disposed)
         {
             _disposed = true;
-            _sessionLogWriter?.Dispose();
-            _sessionLogWriter = null;
+            CloseSessionLogWriter();
             Kill();
             _process?.Dispose();
+        }
+    }
+
+    private void CloseSessionLogWriter()
+    {
+        lock (_sessionLogSync)
+        {
+            _sessionLogWriter?.Dispose();
+            _sessionLogWriter = null;
         }
     }
 }

--- a/PocketMC.Desktop/Features/Instances/Providers/PocketmineProvider.cs
+++ b/PocketMC.Desktop/Features/Instances/Providers/PocketmineProvider.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
-using System.Net.Http.Json;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PocketMC.Desktop.Models;
@@ -13,9 +14,14 @@ namespace PocketMC.Desktop.Features.Instances.Providers;
 
 public class PocketmineProvider : IServerSoftwareProvider
 {
+    private const string ReleasesApiUrl = "https://api.github.com/repos/pmmp/PocketMine-MP/releases";
+    private static readonly TimeSpan ReleaseCacheLifetime = TimeSpan.FromMinutes(10);
     private readonly HttpClient _httpClient;
     private readonly DownloaderService _downloader;
     private readonly ILogger<PocketmineProvider> _logger;
+    private readonly SemaphoreSlim _releaseCacheLock = new(1, 1);
+    private JsonArray? _cachedReleases;
+    private DateTimeOffset _cachedReleasesFetchedAtUtc = DateTimeOffset.MinValue;
 
     public string DisplayName => "Pocketmine-MP (PHP)";
 
@@ -36,7 +42,7 @@ public class PocketmineProvider : IServerSoftwareProvider
         var versions = new List<MinecraftVersion>();
         try
         {
-            var response = await _httpClient.GetFromJsonAsync<JsonArray>("https://api.github.com/repos/pmmp/PocketMine-MP/releases");
+            JsonArray response = await GetReleasesAsync();
             if (response != null)
             {
                 foreach (var node in response)
@@ -61,6 +67,10 @@ public class PocketmineProvider : IServerSoftwareProvider
                 }
             }
         }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Pocketmine release listing is temporarily unavailable.");
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to fetch Pocketmine releases from GitHub.");
@@ -71,10 +81,10 @@ public class PocketmineProvider : IServerSoftwareProvider
     public async Task DownloadSoftwareAsync(string versionId, string destinationPath, IProgress<DownloadProgress>? progress = null)
     {
         _logger.LogInformation("Resolving download URL for Pocketmine {Version}", versionId);
-        
-        var response = await _httpClient.GetFromJsonAsync<JsonArray>("https://api.github.com/repos/pmmp/PocketMine-MP/releases");
+
+        JsonArray response = await GetReleasesAsync();
         string? downloadUrl = null;
-        
+
         if (response != null)
         {
             var release = response.FirstOrDefault(n => n is JsonObject r && r["tag_name"]?.ToString() == versionId) as JsonObject;
@@ -95,5 +105,80 @@ public class PocketmineProvider : IServerSoftwareProvider
         }
 
         await _downloader.DownloadFileAsync(downloadUrl, destinationPath, null, progress);
+    }
+
+    private async Task<JsonArray> GetReleasesAsync()
+    {
+        bool hasFreshCache = _cachedReleases != null &&
+                             DateTimeOffset.UtcNow - _cachedReleasesFetchedAtUtc <= ReleaseCacheLifetime;
+        if (hasFreshCache)
+        {
+            return _cachedReleases!;
+        }
+
+        await _releaseCacheLock.WaitAsync();
+        try
+        {
+            hasFreshCache = _cachedReleases != null &&
+                            DateTimeOffset.UtcNow - _cachedReleasesFetchedAtUtc <= ReleaseCacheLifetime;
+            if (hasFreshCache)
+            {
+                return _cachedReleases!;
+            }
+
+            using HttpRequestMessage request = new(HttpMethod.Get, ReleasesApiUrl);
+            request.Headers.Accept.ParseAdd("application/vnd.github+json");
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            if (response.StatusCode is HttpStatusCode.Forbidden or (HttpStatusCode)429)
+            {
+                throw CreateRateLimitException(response);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(
+                    $"GitHub release API returned {(int)response.StatusCode} ({response.ReasonPhrase}).",
+                    inner: null,
+                    response.StatusCode);
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            JsonNode? payload = await JsonNode.ParseAsync(stream);
+            if (payload is not JsonArray releases)
+            {
+                throw new InvalidOperationException("GitHub release response was not in the expected format.");
+            }
+
+            _cachedReleases = releases;
+            _cachedReleasesFetchedAtUtc = DateTimeOffset.UtcNow;
+            return releases;
+        }
+        finally
+        {
+            _releaseCacheLock.Release();
+        }
+    }
+
+    private static InvalidOperationException CreateRateLimitException(HttpResponseMessage response)
+    {
+        string message = "GitHub API rate limit reached while fetching PocketMine releases. Please try again later.";
+
+        if (response.Headers.TryGetValues("X-RateLimit-Reset", out IEnumerable<string>? resetValues) &&
+            long.TryParse(resetValues.FirstOrDefault(), out long resetEpochSeconds))
+        {
+            DateTimeOffset resetAt = DateTimeOffset.FromUnixTimeSeconds(resetEpochSeconds).ToLocalTime();
+            message = $"GitHub API rate limit reached while fetching PocketMine releases. Try again after {resetAt:yyyy-MM-dd HH:mm zzz}.";
+        }
+        else if (response.Headers.RetryAfter?.Date is DateTimeOffset retryAt)
+        {
+            message = $"GitHub API rate limit reached while fetching PocketMine releases. Try again after {retryAt.ToLocalTime():yyyy-MM-dd HH:mm zzz}.";
+        }
+        else if (response.Headers.RetryAfter?.Delta is TimeSpan retryAfter)
+        {
+            message = $"GitHub API rate limit reached while fetching PocketMine releases. Try again in about {Math.Ceiling(retryAfter.TotalMinutes)} minute(s).";
+        }
+
+        return new InvalidOperationException(message);
     }
 }

--- a/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
@@ -11,6 +11,7 @@ namespace PocketMC.Desktop.Features.Instances.Services;
     public class DownloaderService
     {
         private const string DownloadClientName = "PocketMC.Downloads";
+        private const string PlayitDownloadUrl = "https://github.com/playit-cloud/playit-agent/releases/latest/download/playit-windows-x86_64.exe";
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<DownloaderService> _logger;
 
@@ -28,7 +29,7 @@ namespace PocketMC.Desktop.Features.Instances.Services;
             CancellationToken cancellationToken = default)
         {
             string partialPath = destinationPath + ".partial";
-            bool allowResume = !string.IsNullOrWhiteSpace(expectedHash);
+            bool allowResume = CanResumeDownload(expectedHash);
             string? directory = Path.GetDirectoryName(destinationPath);
             if (!string.IsNullOrEmpty(directory))
             {
@@ -134,11 +135,6 @@ namespace PocketMC.Desktop.Features.Instances.Services;
         /// </summary>
         public async Task EnsurePlayitDownloadedAsync(string appRootPath, IProgress<DownloadProgress>? progress = null, CancellationToken cancellationToken = default)
         {
-            // Note: For 'latest' URL, the hash isn't stable. 
-            // Ideally, we should fetch the hash from a sidecar file or pin the version.
-            // For now, we allow the download but provide the hook for verification.
-            const string playitDownloadUrl = "https://github.com/playit-cloud/playit-agent/releases/latest/download/playit-windows-x86_64.exe";
-
             string tunnelDir = Path.Combine(appRootPath, "tunnel");
             string playitPath = Path.Combine(tunnelDir, "playit.exe");
 
@@ -148,9 +144,19 @@ namespace PocketMC.Desktop.Features.Instances.Services;
             }
 
             Directory.CreateDirectory(tunnelDir);
-            await DownloadFileAsync(playitDownloadUrl, playitPath, null, progress, cancellationToken);
+            await DownloadFileAsync(PlayitDownloadUrl, playitPath, GetPlayitExpectedHash(), progress, cancellationToken);
         }
 // ... rest of file (ExtractZipAsync, etc.)
+
+        public bool CanResumeDownload(string? expectedHash)
+        {
+            return !string.IsNullOrWhiteSpace(expectedHash);
+        }
+
+        public bool CanResumePlayitDownload()
+        {
+            return CanResumeDownload(GetPlayitExpectedHash());
+        }
 
         public Task ExtractZipAsync(string zipPath, string extractPath, IProgress<DownloadProgress>? progress = null)
         {
@@ -281,5 +287,11 @@ namespace PocketMC.Desktop.Features.Instances.Services;
             {
                 // Best effort cleanup only.
             }
+        }
+
+        private static string? GetPlayitExpectedHash()
+        {
+            // Playit currently uses a "latest" URL, so a stable hash is unavailable.
+            return null;
         }
     }

--- a/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
@@ -28,6 +28,7 @@ namespace PocketMC.Desktop.Features.Instances.Services;
             CancellationToken cancellationToken = default)
         {
             string partialPath = destinationPath + ".partial";
+            bool allowResume = !string.IsNullOrWhiteSpace(expectedHash);
             string? directory = Path.GetDirectoryName(destinationPath);
             if (!string.IsNullOrEmpty(directory))
             {
@@ -44,7 +45,13 @@ namespace PocketMC.Desktop.Features.Instances.Services;
                 try
                 {
                     using HttpClient client = _httpClientFactory.CreateClient(DownloadClientName);
-                    long existingBytes = GetExistingPartialLength(partialPath);
+                    if (!allowResume && File.Exists(partialPath))
+                    {
+                        _logger.LogInformation("Discarding unverified partial download for {Url}; resume requires a trusted hash.", url);
+                        TryDeleteFile(partialPath);
+                    }
+
+                    long existingBytes = allowResume ? GetExistingPartialLength(partialPath) : 0;
                     using HttpRequestMessage request = new(HttpMethod.Get, url);
                     if (existingBytes > 0)
                     {
@@ -241,11 +248,6 @@ namespace PocketMC.Desktop.Features.Instances.Services;
 
                 try
                 {
-                    if (File.Exists(destinationPath))
-                    {
-                        File.Delete(destinationPath);
-                    }
-
                     File.Move(partialPath, destinationPath, overwrite: true);
                     return;
                 }
@@ -281,4 +283,3 @@ namespace PocketMC.Desktop.Features.Instances.Services;
             }
         }
     }
-

--- a/PocketMC.Desktop/Features/Instances/Services/ServerLifecycleService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/ServerLifecycleService.cs
@@ -33,6 +33,7 @@ public class ServerLifecycleService : IServerLifecycleService, IDisposable
     private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _restartCancellations = new();
     private readonly ConcurrentDictionary<Guid, DateTime> _sessionStartTimes = new();
     private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _startLocks = new();
+    private readonly SemaphoreSlim _portReservationLock = new(1, 1);
 
     public event Action<Guid, ServerState>? OnInstanceStateChanged;
     public event Action<Guid, int>? OnRestartCountdownTick;
@@ -90,22 +91,31 @@ public class ServerLifecycleService : IServerLifecycleService, IDisposable
             {
                 try
                 {
-                    var preflightResult = _portPreflightService.Check(meta, instancePath);
-                    if (!preflightResult.IsSuccessful)
-                        throw CreatePortReliabilityException(new[] { preflightResult }, recoveryAttempt);
+                    await _portReservationLock.WaitAsync();
+                    try
+                    {
+                        var preflightResult = _portPreflightService.Check(meta, instancePath);
+                        if (!preflightResult.IsSuccessful)
+                            throw CreatePortReliabilityException(new[] { preflightResult }, recoveryAttempt);
 
-                    IReadOnlyList<PortCheckRequest> portRequests = _portPreflightService.BuildRequests(meta, instancePath);
-                    PortCheckResult[] failedProbeResults = _portProbeService.ProbeMany(portRequests)
-                        .Where(result => !result.IsSuccessful)
-                        .ToArray();
+                        IReadOnlyList<PortCheckRequest> portRequests = _portPreflightService.BuildRequests(meta, instancePath);
+                        PortCheckResult[] failedProbeResults = _portProbeService.ProbeMany(portRequests)
+                            .Where(result => !result.IsSuccessful)
+                            .ToArray();
 
-                    if (failedProbeResults.Length > 0)
-                        throw CreatePortReliabilityException(failedProbeResults, recoveryAttempt);
+                        if (failedProbeResults.Length > 0)
+                            throw CreatePortReliabilityException(failedProbeResults, recoveryAttempt);
 
-                    leasesAcquired = true;
-                    PortCheckResult? leaseFailure = TryReservePortLeases(meta, instancePath, portRequests);
-                    if (leaseFailure != null)
-                        throw CreatePortReliabilityException(new[] { leaseFailure }, recoveryAttempt);
+                        PortCheckResult? leaseFailure = TryReservePortLeases(meta, instancePath, portRequests);
+                        if (leaseFailure != null)
+                            throw CreatePortReliabilityException(new[] { leaseFailure }, recoveryAttempt);
+
+                        leasesAcquired = true;
+                    }
+                    finally
+                    {
+                        _portReservationLock.Release();
+                    }
 
                     break;
                 }
@@ -244,6 +254,7 @@ public class ServerLifecycleService : IServerLifecycleService, IDisposable
             startLock.Dispose();
         }
 
+        _portReservationLock.Dispose();
         _startLocks.Clear();
         _sessionStartTimes.Clear();
         _lastStartTime.Clear();
@@ -317,6 +328,8 @@ public class ServerLifecycleService : IServerLifecycleService, IDisposable
 
     private PortCheckResult? TryReservePortLeases(InstanceMetadata meta, string instancePath, IReadOnlyList<PortCheckRequest> portRequests)
     {
+        var reservedRequests = new List<PortCheckRequest>(portRequests.Count);
+
         foreach (PortCheckRequest request in portRequests)
         {
             var lease = new PortLease(
@@ -330,8 +343,11 @@ public class ServerLifecycleService : IServerLifecycleService, IDisposable
 
             if (_portLeaseRegistry.TryReserve(lease, out PortLease? conflictingLease))
             {
+                reservedRequests.Add(request);
                 continue;
             }
+
+            ReleaseReservedPortLeases(meta.Id, reservedRequests);
 
             var conflict = new PortConflictInfo(
                 PortFailureCode.InUseByPocketMcInstance,
@@ -367,6 +383,19 @@ public class ServerLifecycleService : IServerLifecycleService, IDisposable
         }
 
         return null;
+    }
+
+    private void ReleaseReservedPortLeases(Guid instanceId, IReadOnlyList<PortCheckRequest> reservedRequests)
+    {
+        foreach (PortCheckRequest reserved in reservedRequests)
+        {
+            _portLeaseRegistry.Release(
+                instanceId,
+                reserved.Port,
+                reserved.Protocol,
+                reserved.IpMode,
+                reserved.BindAddress);
+        }
     }
 
     private void CleanupInstanceNetworking(Guid instanceId)

--- a/PocketMC.Desktop/Features/Mods/AddonManifest.cs
+++ b/PocketMC.Desktop/Features/Mods/AddonManifest.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PocketMC.Desktop.Features.Mods;
+
+/// <summary>
+/// Stores metadata for addons installed into a target directory (mods/plugins/etc.).
+/// </summary>
+public sealed class AddonManifest
+{
+    private const string ManifestFileName = ".pocketmc-addon-manifest.json";
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Loads the current addon manifest entries for the provided directory.
+    /// </summary>
+    public async Task<IReadOnlyList<AddonManifestEntry>> LoadAsync(string addonsDirectory, CancellationToken cancellationToken = default)
+    {
+        string manifestPath = GetManifestPath(addonsDirectory);
+        if (!File.Exists(manifestPath))
+        {
+            return Array.Empty<AddonManifestEntry>();
+        }
+
+        await using FileStream stream = new(manifestPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        List<AddonManifestEntry>? entries = await JsonSerializer.DeserializeAsync<List<AddonManifestEntry>>(stream, JsonOptions, cancellationToken);
+        return entries ?? Array.Empty<AddonManifestEntry>();
+    }
+
+    /// <summary>
+    /// Persists the supplied entries as the manifest for the provided directory.
+    /// </summary>
+    public async Task SaveAsync(string addonsDirectory, IReadOnlyCollection<AddonManifestEntry> entries, CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(addonsDirectory);
+        string manifestPath = GetManifestPath(addonsDirectory);
+
+        await using FileStream stream = new(manifestPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        await JsonSerializer.SerializeAsync(stream, entries, JsonOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Removes entries whose backing files were deleted and writes the cleaned manifest.
+    /// </summary>
+    public async Task<IReadOnlyList<AddonManifestEntry>> SyncManifestAsync(string addonsDirectory, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<AddonManifestEntry> existing = await LoadAsync(addonsDirectory, cancellationToken);
+        AddonManifestEntry[] filtered = existing
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.FileName))
+            .Where(entry => File.Exists(Path.Combine(addonsDirectory, entry.FileName)))
+            .ToArray();
+
+        await SaveAsync(addonsDirectory, filtered, cancellationToken);
+        return filtered;
+    }
+
+    private static string GetManifestPath(string addonsDirectory) =>
+        Path.Combine(addonsDirectory, ManifestFileName);
+}
+
+public sealed class AddonManifestEntry
+{
+    [JsonPropertyName("fileName")]
+    public string FileName { get; set; } = string.Empty;
+
+    [JsonPropertyName("projectId")]
+    public string ProjectId { get; set; } = string.Empty;
+
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = string.Empty;
+
+    [JsonPropertyName("versionId")]
+    public string VersionId { get; set; } = string.Empty;
+
+    [JsonPropertyName("installedAt")]
+    public DateTime InstalledAt { get; set; } = DateTime.UtcNow;
+}

--- a/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
+++ b/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using PocketMC.Desktop.Features.Instances;
 
 namespace PocketMC.Desktop.Features.Mods;
 
@@ -283,9 +284,10 @@ public sealed class BedrockAddonInstaller : IAddonManager
 
     private static string ResolveWorldDirectory(string serverDir)
     {
-        // BDS stores worlds under [server]/worlds/<WorldName>/
-        // Prefer the default directory but fall back to the first existing world dir.
-        string preferred = Path.Combine(serverDir, WorldsDir, DefaultWorldName);
+        // BDS stores worlds under [server]/worlds/<WorldName>/, where <WorldName>
+        // comes from server.properties -> level-name.
+        string configuredWorldName = ResolveConfiguredWorldName(serverDir);
+        string preferred = Path.Combine(serverDir, WorldsDir, configuredWorldName);
         if (Directory.Exists(preferred)) return preferred;
 
         var worldsParent = Path.Combine(serverDir, WorldsDir);
@@ -295,9 +297,22 @@ public sealed class BedrockAddonInstaller : IAddonManager
             if (first != null) return first;
         }
 
-        // If no world directory exists yet, create the default one.
+        // If no world directory exists yet, create the configured/default one.
         Directory.CreateDirectory(preferred);
         return preferred;
+    }
+
+    private static string ResolveConfiguredWorldName(string serverDir)
+    {
+        string propertiesPath = Path.Combine(serverDir, "server.properties");
+        Dictionary<string, string> properties = ServerPropertiesParser.Read(propertiesPath);
+        if (!properties.TryGetValue("level-name", out string? levelName) || string.IsNullOrWhiteSpace(levelName))
+        {
+            return DefaultWorldName;
+        }
+
+        string trimmed = levelName.Trim();
+        return string.Concat(trimmed.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c));
     }
 
     private static void CollectAddons(string dir, string addonType, List<AddonInfo> output)

--- a/PocketMC.Desktop/Features/Tunnel/PlayitAgentService.cs
+++ b/PocketMC.Desktop/Features/Tunnel/PlayitAgentService.cs
@@ -58,6 +58,7 @@ namespace PocketMC.Desktop.Features.Tunnel
         public PlayitAgentState State => _stateMachine.State;
         public bool IsDownloadingBinary => _isDownloadingBinary;
         public bool IsBinaryAvailable => _applicationState.IsConfigured && File.Exists(_applicationState.GetPlayitExecutablePath());
+        public bool CanResumeDownload => _downloaderService.CanResumePlayitDownload();
         public bool IsRunning => _processManager.IsRunning;
 
         public event EventHandler<string>? OnClaimUrlReceived;

--- a/PocketMC.Desktop/Features/Tunnel/TunnelPage.xaml.cs
+++ b/PocketMC.Desktop/Features/Tunnel/TunnelPage.xaml.cs
@@ -133,13 +133,14 @@ namespace PocketMC.Desktop.Features.Tunnel
                 SetUiState(TunnelUiState.Missing, "Missing", "PocketMC is not configured with an app root path yet.", Brushes.Orange);
                 TxtExecutablePath.Text = "App root not configured";
                 ShowNoTunnels("Finish PocketMC setup before managing tunnels.");
-                UpdateActionButtons(binaryExists: false);
+                UpdateActionButtons(binaryExists: false, canResumeDownload: false);
                 return;
             }
 
             string executablePath = _applicationState.GetPlayitExecutablePath();
             bool binaryExists = File.Exists(executablePath);
             bool partialExists = File.Exists(executablePath + ".partial");
+            bool canResumeDownload = _playitAgentService.CanResumeDownload;
 
             TxtExecutablePath.Text = executablePath;
             bool isDownloading = _playitAgentService.IsDownloadingBinary;
@@ -154,18 +155,18 @@ namespace PocketMC.Desktop.Features.Tunnel
             {
                 SetUiState(TunnelUiState.Downloading, "Downloading", "PocketMC is downloading the Playit.gg agent.", Brushes.DeepSkyBlue);
                 ShowNoTunnels("The tunnel list will appear after the agent is downloaded and connected.");
-                UpdateActionButtons(binaryExists);
+                UpdateActionButtons(binaryExists, partialExists && canResumeDownload);
                 return;
             }
 
             if (!binaryExists)
             {
-                string detail = partialExists
+                string detail = partialExists && canResumeDownload
                     ? "A partial agent download was found. Click Download Agent to resume the transfer."
                     : "playit.exe is missing from the tunnel folder. Download the agent to enable public tunnels.";
                 SetUiState(TunnelUiState.Missing, "Missing", detail, Brushes.Orange);
                 ShowNoTunnels("Download the Playit agent to begin tunnel setup.");
-                UpdateActionButtons(binaryExists: false);
+                UpdateActionButtons(binaryExists: false, canResumeDownload: partialExists && canResumeDownload);
                 return;
             }
 
@@ -174,18 +175,18 @@ namespace PocketMC.Desktop.Features.Tunnel
                 case PlayitAgentState.Starting:
                     SetUiState(TunnelUiState.Starting, "Starting", "Launching the Playit agent and waiting for the tunnel service to come online.", Brushes.Gold);
                     ShowNoTunnels("Waiting for the Playit agent to finish starting.");
-                    UpdateActionButtons(binaryExists: true);
+                    UpdateActionButtons(binaryExists: true, canResumeDownload: false);
                     return;
 
                 case PlayitAgentState.WaitingForClaim:
                     SetUiState(TunnelUiState.WaitingForClaim, "Waiting for Claim", "Approve the Playit claim flow in your browser to finish linking PocketMC, or click Connect to restart the claim flow.", Brushes.Gold);
                     ShowNoTunnels("Complete the claim flow to load your tunnel inventory.");
-                    UpdateActionButtons(binaryExists: true);
+                    UpdateActionButtons(binaryExists: true, canResumeDownload: false);
                     return;
 
                 case PlayitAgentState.Connected:
                     await RefreshTunnelInventoryAsync(refreshVersion);
-                    UpdateActionButtons(binaryExists: true);
+                    UpdateActionButtons(binaryExists: true, canResumeDownload: false);
                     return;
 
                 case PlayitAgentState.Error:
@@ -194,7 +195,7 @@ namespace PocketMC.Desktop.Features.Tunnel
                 default:
                     SetUiState(TunnelUiState.Ready, "Ready", "The agent is installed but not connected. Click Connect to retry the tunnel session.", Brushes.Silver);
                     ShowNoTunnels("Connect the Playit agent to load tunnel information.");
-                    UpdateActionButtons(binaryExists: true);
+                    UpdateActionButtons(binaryExists: true, canResumeDownload: false);
                     return;
             }
         }
@@ -314,14 +315,13 @@ namespace PocketMC.Desktop.Features.Tunnel
             }
         }
 
-        private void UpdateActionButtons(bool binaryExists)
+        private void UpdateActionButtons(bool binaryExists, bool canResumeDownload)
         {
-            bool partialExists = _applicationState.IsConfigured && File.Exists(_applicationState.GetPlayitExecutablePath() + ".partial");
             bool isDownloading = _playitAgentService.IsDownloadingBinary;
 
             BtnDownloadAgent.Visibility = binaryExists ? Visibility.Collapsed : Visibility.Visible;
             BtnDownloadAgent.IsEnabled = !isDownloading;
-            BtnDownloadAgent.Content = partialExists ? "Resume Download" : "Download Agent";
+            BtnDownloadAgent.Content = canResumeDownload ? "Resume Download" : "Download Agent";
 
             BtnConnect.Content = _currentUiState == TunnelUiState.WaitingForClaim ? "Reconnect" : "Connect";
             BtnConnect.IsEnabled =
@@ -373,7 +373,7 @@ namespace PocketMC.Desktop.Features.Tunnel
                 SetUiState(TunnelUiState.Ready, "Ready", $"PocketMC could not start the agent: {ex.Message}", Brushes.Orange);
             }
 
-            UpdateActionButtons(binaryExists: true);
+            UpdateActionButtons(binaryExists: true, canResumeDownload: false);
             await RefreshStatusAsync();
         }
 

--- a/PocketMC.Desktop/Navigation/ControlledNavigationStack.cs
+++ b/PocketMC.Desktop/Navigation/ControlledNavigationStack.cs
@@ -79,16 +79,23 @@ public sealed class ControlledNavigationStack
         }
 
         ControlledNavigationEntry removed = _entries[^1];
-        _entries.RemoveAt(_entries.Count - 1);
 
         if (removed.BackTarget.Kind == NavigationBackTargetKind.PreviousDetail)
         {
-            if (_entries.Count == 0)
+            if (_entries.Count == 1)
             {
-                throw new InvalidOperationException(
-                    $"Route {removed.Route} expected a previous detail route, but the stack is empty.");
+                // Heal inconsistent state (for example, if the stack was externally mutated)
+                // by falling back to the default shell route instead of throwing.
+                _entries.Clear();
+                return new ControlledBackNavigationResult(
+                    true,
+                    removed.EntryId,
+                    NavigationRouteKind.Dashboard,
+                    null,
+                    true);
             }
 
+            _entries.RemoveAt(_entries.Count - 1);
             ControlledNavigationEntry target = _entries[^1];
             return new ControlledBackNavigationResult(
                 true,
@@ -98,6 +105,7 @@ public sealed class ControlledNavigationStack
                 false);
         }
 
+        _entries.RemoveAt(_entries.Count - 1);
         _entries.Clear();
         return new ControlledBackNavigationResult(
             true,


### PR DESCRIPTION
### Motivation
- Prevent races where two instances both pass probe and then contend for reservations during startup, which could leak partial leases or allow confusing cleanup behavior.
- Ensure `leasesAcquired` accurately reflects that all required leases were reserved, not set before reservation attempts.
- Provide deterministic cleanup when a later reservation in a multi-port batch fails so earlier successful reservations are rolled back immediately.

### Description
- Serialize the preflight → probe → reserve sequence with a new semaphore `_portReservationLock` to close the in-process probe→reserve window during concurrent starts by moving that work inside the critical section in `StartAsync`.
- Only set `leasesAcquired = true` after all required leases are successfully reserved (moved after `TryReservePortLeases` completes successfully).
- Add rollback logic in `TryReservePortLeases` that tracks already-reserved requests and calls `ReleaseReservedPortLeases` to release them if a subsequent reservation fails.
- Dispose the new `_portReservationLock` in `Dispose` and add a regression unit test `StartAsync_WhenLeaseConflictOccursAfterPartialReservation_RollsBackAlreadyReservedLeases` validating no leases are leaked on partial reservation failure.

### Testing
- Added unit test `StartAsync_WhenLeaseConflictOccursAfterPartialReservation_RollsBackAlreadyReservedLeases` to `ServerLifecycleServiceTests` which pre-reserves a competing Geyser lease and verifies the failing instance releases any partial leases.
- Existing tests covering lease cleanup on launch failure remain; new test exercises multi-port (Java + Geyser) conflict scenario and assertions about registry state.
- Attempted to run `dotnet test PocketMC.Desktop.Tests/PocketMC.Desktop.Tests.csproj --filter "FullyQualifiedName~ServerLifecycleServiceTests"`, but the test run could not be executed in this environment because the `dotnet` CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fca2c3c8833396fd3b3dc9db7c85)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup reliability by serializing port reservations and rolling back partial reservations on conflict.
  * Safer backup restore: attempts RCON save-on first, falling back to console only if needed.
  * Prevented unsafe resume of untrusted partial downloads by discarding stale partials when no expected hash is present.

* **New Features**
  * Addon manifest management and sync to track installed addon files.
  * Download UI now shows “Resume Download” when resumable; exposes resumability flag for the tunnel agent.
  * Provider release fetching now caches results and surfaces friendly rate-limit messages.

* **Refactor**
  * Made session logging and disposal thread-safe.

* **Tests**
  * Added extensive tests for port lease rollback, download resume behavior, addon installer/manifest, providers, and navigation stack healing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->