### PR TITLE
Fix path traversal, temp path conflicts, and process leaks

### DIFF
--- a/PocketMC.Desktop/Features/Instances/Services/PhpProvisioningService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/PhpProvisioningService.cs
@@ -52,7 +52,7 @@ public class PhpProvisioningService
         string appRoot = _applicationState.GetRequiredAppRootPath();
         string runtimesDir = Path.Combine(appRoot, "runtimes");
         string phpDir = Path.Combine(runtimesDir, "php");
-        string tempZipPath = Path.Combine(runtimesDir, "php_temp.zip");
+        string tempZipPath = Path.Combine(runtimesDir, $"php_temp_{Guid.NewGuid():N}.zip");
 
         Directory.CreateDirectory(runtimesDir);
 

--- a/PocketMC.Desktop/Features/Java/JavaProvisioningService.cs
+++ b/PocketMC.Desktop/Features/Java/JavaProvisioningService.cs
@@ -157,7 +157,7 @@ namespace PocketMC.Desktop.Features.Java
 
             string appRootPath = _applicationState.GetRequiredAppRootPath();
             string runtimeDir = Path.Combine(appRootPath, "runtime");
-            string tempZipPath = Path.Combine(runtimeDir, $"temp_java{version}.zip");
+            string tempZipPath = Path.Combine(runtimeDir, $"temp_java{version}_{Guid.NewGuid():N}.zip");
             string extractPath = Path.Combine(runtimeDir, $"java{version}_ext");
             string finalPath = Path.Combine(runtimeDir, $"java{version}");
 

--- a/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
+++ b/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using PocketMC.Desktop.Features.Instances.Backups;
 
 namespace PocketMC.Desktop.Features.Mods;
 
@@ -68,7 +69,7 @@ public sealed class BedrockAddonInstaller : IAddonManager
         {
             Directory.CreateDirectory(tempDir);
             _logger.LogInformation("Extracting addon {File} to temp dir {TempDir}.", sourceFilePath, tempDir);
-            await Task.Run(() => ZipFile.ExtractToDirectory(sourceFilePath, tempDir, overwriteFiles: true), ct);
+            await SafeZipExtractor.ExtractAsync(sourceFilePath, tempDir);
 
             var manifests = FindManifests(tempDir);
             if (manifests.Count == 0)

--- a/PocketMC.Desktop/Features/Tunnel/PlayitSetupWizardPage.xaml.cs
+++ b/PocketMC.Desktop/Features/Tunnel/PlayitSetupWizardPage.xaml.cs
@@ -134,7 +134,7 @@ namespace PocketMC.Desktop.Features.Tunnel
 
             try
             {
-                Process.Start(new ProcessStartInfo
+                using var proc = Process.Start(new ProcessStartInfo
                 {
                     FileName = setupUri.AbsoluteUri,
                     UseShellExecute = true


### PR DESCRIPTION
This PR addresses several security risks and resource leaks discovered during an audit of the repository:

1.  **Zip Slip Vulnerability:** Direct use of `ZipFile.ExtractToDirectory` in `BedrockAddonInstaller` without path traversal checks could lead to arbitrary file write outside the intended directory. This has been fixed by using the existing `SafeZipExtractor.ExtractAsync` utility, which validates extraction paths.
2.  **Process Resource Leaks:** Improper disposal of `Process.Start` in `PlayitSetupWizardPage.xaml.cs` could lead to resource leaks over time. This has been fixed by wrapping the process instance in a `using` block.
3.  **Predictable Temporary File Paths:** Use of hardcoded/predictable temp file paths (`php_temp.zip`, `temp_java{version}.zip`) in `PhpProvisioningService` and `JavaProvisioningService` introduces potential race conditions or tampering risks during runtime provisioning if multiple instances provision concurrently. This has been fixed by appending a generated `Guid` to the file names to ensure uniqueness.

---
*PR created automatically by Jules for task [1487706530663806847](https://jules.google.com/task/1487706530663806847) started by @Sahaj33-op*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved potential conflicts in concurrent PHP and Java provisioning by using unique temporary file names per installation attempt.

* **Improvements**
  * Enhanced addon installation safety with improved extraction handling.
  * Improved resource cleanup when launching external processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->