### PR TITLE
Harden DPAPI, path validation, and process I/O handling

### DIFF
--- a/PocketMC.Desktop.Tests/AddonManifestTests.cs
+++ b/PocketMC.Desktop.Tests/AddonManifestTests.cs
@@ -77,5 +77,32 @@ namespace PocketMC.Desktop.Tests
             Assert.Single(updated.Entries);
             Assert.Equal("mod-a", updated.Entries[0].ProjectId);
         }
+
+        [Fact]
+        public async Task IsInstalledAsync_ReturnsFalseAndCleansEntry_WhenManifestFileNameEscapesAddonDirectory()
+        {
+            var service = new AddonManifestService();
+            var manifest = new AddonManifest();
+            manifest.Entries.Add(new AddonManifestEntry
+            {
+                ProjectId = "mod-a",
+                FileName = Path.Combine("..", "outside.jar"),
+                Provider = "Modrinth"
+            });
+
+            Directory.CreateDirectory(Path.Combine(_tempDir, "mods"));
+            File.WriteAllText(Path.Combine(_tempDir, "outside.jar"), "not an installed addon");
+            await service.SaveManifestAsync(_tempDir, manifest);
+
+            bool installed = await service.IsInstalledAsync(
+                _tempDir,
+                "Modrinth",
+                "mod-a",
+                new EngineCompatibility("Fabric"));
+
+            Assert.False(installed);
+            AddonManifest updated = await service.LoadManifestAsync(_tempDir);
+            Assert.Empty(updated.Entries);
+        }
     }
 }

--- a/PocketMC.Desktop.Tests/BackupManifestSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/BackupManifestSecurityTests.cs
@@ -1,0 +1,41 @@
+using PocketMC.Desktop.Features.Instances.Backups;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class BackupManifestSecurityTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "PocketMC_BackupManifest_" + Guid.NewGuid());
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup for temp files.
+        }
+    }
+
+    [Fact]
+    public void PurgeOrphanedEntries_RemovesEntriesThatEscapeBackupDirectory()
+    {
+        string serverDir = Path.Combine(_root, "server");
+        Directory.CreateDirectory(Path.Combine(serverDir, "backups"));
+        File.WriteAllText(Path.Combine(serverDir, "outside.zip"), "outside");
+
+        var manifest = new BackupManifest();
+        manifest.Entries.Add(new BackupMetadataEntry
+        {
+            FileName = Path.Combine("..", "outside.zip")
+        });
+
+        manifest.PurgeOrphanedEntries(serverDir);
+
+        Assert.Empty(manifest.Entries);
+    }
+}

--- a/PocketMC.Desktop.Tests/BackupServiceSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/BackupServiceSecurityTests.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging.Abstractions;
+using PocketMC.Desktop.Features.Instances.Backups;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class BackupServiceSecurityTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "PocketMC_BackupSecurity_" + Guid.NewGuid());
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup for temp files.
+        }
+    }
+
+    [Fact]
+    public void VerifyBackupIntegrity_ReturnsFalse_WhenManifestFileNameEscapesBackupsDirectory()
+    {
+        string serverDir = Path.Combine(_root, "server");
+        Directory.CreateDirectory(Path.Combine(serverDir, "backups"));
+
+        string escapedFileName = Path.Combine("..", "outside.zip");
+        string outsidePath = Path.Combine(serverDir, "outside.zip");
+        File.WriteAllText(outsidePath, "outside backup");
+
+        var manifest = new BackupManifest();
+        manifest.Entries.Add(new BackupMetadataEntry
+        {
+            FileName = escapedFileName,
+            Sha256Checksum = ComputeSha256(outsidePath)
+        });
+        manifest.Save(serverDir);
+
+        var service = new BackupService(null!, null!, null!, null!, NullLogger<BackupService>.Instance);
+
+        Assert.False(service.VerifyBackupIntegrity(serverDir, escapedFileName));
+    }
+
+    private static string ComputeSha256(string filePath)
+    {
+        byte[] hash = SHA256.HashData(File.ReadAllBytes(filePath));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}

--- a/PocketMC.Desktop.Tests/BedrockAddonInstallerSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/BedrockAddonInstallerSecurityTests.cs
@@ -10,6 +10,51 @@ public sealed class BedrockAddonInstallerSecurityTests : IDisposable
     private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), "PocketMC.Tests", Guid.NewGuid().ToString("N"));
 
     [Fact]
+    public async Task UninstallAsync_DeletesPackAndScrubsWorldJson()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        string serverDir = Path.Combine(_tempDirectory, "server");
+        string packDir = Path.Combine(serverDir, "behavior_packs", "TestPack");
+        Directory.CreateDirectory(packDir);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(packDir, "manifest.json"),
+            """
+            {
+              "header": {
+                "name": "TestPack",
+                "uuid": "d15c1f4d-a87f-4edc-8af1-2b5683cb6698",
+                "version": [1, 0, 0]
+              },
+              "modules": [
+                { "type": "data" }
+              ]
+            }
+            """);
+
+        string worldDir = Path.Combine(serverDir, "worlds", "Bedrock level");
+        Directory.CreateDirectory(worldDir);
+        string worldJson = Path.Combine(worldDir, "world_behavior_packs.json");
+        await File.WriteAllTextAsync(
+            worldJson,
+            """
+            [
+              { "pack_id": "d15c1f4d-a87f-4edc-8af1-2b5683cb6698", "version": [1, 0, 0] },
+              { "pack_id": "11111111-1111-1111-1111-111111111111", "version": [1, 0, 0] }
+            ]
+            """);
+
+        var installer = new BedrockAddonInstaller(NullLogger<BedrockAddonInstaller>.Instance);
+
+        await installer.UninstallAsync("TestPack", serverDir);
+
+        Assert.False(Directory.Exists(packDir));
+        string updatedJson = await File.ReadAllTextAsync(worldJson);
+        Assert.DoesNotContain("d15c1f4d-a87f-4edc-8af1-2b5683cb6698", updatedJson, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("11111111-1111-1111-1111-111111111111", updatedJson, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task InstallAsync_DoesNotDeletePackRoot_WhenManifestNameSanitizesToEmpty()
     {
         Directory.CreateDirectory(_tempDirectory);

--- a/PocketMC.Desktop.Tests/BedrockAddonInstallerSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/BedrockAddonInstallerSecurityTests.cs
@@ -116,6 +116,7 @@ public sealed class BedrockAddonInstallerSecurityTests : IDisposable
         Assert.Contains("catch (IOException)", source, StringComparison.Ordinal);
         Assert.Contains("catch (UnauthorizedAccessException)", source, StringComparison.Ordinal);
         Assert.Contains("catch (JsonException)", source, StringComparison.Ordinal);
+        Assert.Contains("catch (InvalidOperationException)", source, StringComparison.Ordinal);
         Assert.Contains("catch (NotSupportedException)", source, StringComparison.Ordinal);
 
         int methodStart = source.IndexOf("private static async Task<string?> TryReadUuidAsync", StringComparison.Ordinal);

--- a/PocketMC.Desktop.Tests/BedrockAddonInstallerSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/BedrockAddonInstallerSecurityTests.cs
@@ -91,6 +91,40 @@ public sealed class BedrockAddonInstallerSecurityTests : IDisposable
         Assert.True(File.Exists(canaryPath));
     }
 
+    [Fact]
+    public void ProcessManifestAsync_ValidatesTargetPackRootBeforeCombiningPackName()
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(
+            "PocketMC.Desktop",
+            "Features",
+            "Mods",
+            "BedrockAddonInstaller.cs"));
+
+        Assert.Contains("PathSafety.ValidateContainedPath(serverDir, targetSubDir)", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("string packsRoot = Path.Combine(serverDir, targetSubDir);", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryReadUuidAsync_OnlySuppressesExpectedReadAndJsonFailures()
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(
+            "PocketMC.Desktop",
+            "Features",
+            "Mods",
+            "BedrockAddonInstaller.cs"));
+
+        Assert.Contains("catch (IOException)", source, StringComparison.Ordinal);
+        Assert.Contains("catch (UnauthorizedAccessException)", source, StringComparison.Ordinal);
+        Assert.Contains("catch (JsonException)", source, StringComparison.Ordinal);
+        Assert.Contains("catch (NotSupportedException)", source, StringComparison.Ordinal);
+
+        int methodStart = source.IndexOf("private static async Task<string?> TryReadUuidAsync", StringComparison.Ordinal);
+        int methodEnd = source.IndexOf("    // ── World JSON management", methodStart, StringComparison.Ordinal);
+        string methodSource = source[methodStart..methodEnd];
+        Assert.DoesNotContain("catch\r\n", methodSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("catch\n", methodSource, StringComparison.Ordinal);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))

--- a/PocketMC.Desktop.Tests/BedrockAddonInstallerSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/BedrockAddonInstallerSecurityTests.cs
@@ -1,0 +1,56 @@
+using System.IO.Compression;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using PocketMC.Desktop.Features.Mods;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class BedrockAddonInstallerSecurityTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), "PocketMC.Tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task InstallAsync_DoesNotDeletePackRoot_WhenManifestNameSanitizesToEmpty()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        string serverDir = Path.Combine(_tempDirectory, "server");
+        string behaviorPacksDir = Path.Combine(serverDir, "behavior_packs");
+        Directory.CreateDirectory(behaviorPacksDir);
+        string canaryPath = Path.Combine(behaviorPacksDir, "canary.txt");
+        await File.WriteAllTextAsync(canaryPath, "still here");
+
+        string addonPath = Path.Combine(_tempDirectory, "bad.mcpack");
+        using (var archive = ZipFile.Open(addonPath, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry("manifest.json");
+            await using var stream = entry.Open();
+            await using var writer = new StreamWriter(stream, Encoding.UTF8);
+            await writer.WriteAsync("""
+            {
+              "header": {
+                "name": "...",
+                "uuid": "d15c1f4d-a87f-4edc-8af1-2b5683cb6698",
+                "version": [1, 0, 0]
+              },
+              "modules": [
+                { "type": "data" }
+              ]
+            }
+            """);
+        }
+
+        var installer = new BedrockAddonInstaller(NullLogger<BedrockAddonInstaller>.Instance);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => installer.InstallAsync(addonPath, serverDir));
+        Assert.True(Directory.Exists(behaviorPacksDir));
+        Assert.True(File.Exists(canaryPath));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/PocketMC.Desktop.Tests/DataProtectorTests.cs
+++ b/PocketMC.Desktop.Tests/DataProtectorTests.cs
@@ -21,9 +21,17 @@ public sealed class DataProtectorTests
     }
 
     [Fact]
-    public void Unprotect_Throws_WhenBase64PayloadCannotBeDecrypted()
+    public void Unprotect_ReturnsLegacyPlaintext_WhenUnprefixedBase64CannotBeDecrypted()
     {
-        string corruptedPayload = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        string legacySecret = Convert.ToBase64String("legacy-secret"u8.ToArray());
+
+        Assert.Equal(legacySecret, DataProtector.Unprotect(legacySecret));
+    }
+
+    [Fact]
+    public void Unprotect_Throws_WhenPrefixedBase64PayloadCannotBeDecrypted()
+    {
+        string corruptedPayload = "dpapi:v1:" + Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
 
         Assert.Throws<CryptographicException>(() => DataProtector.Unprotect(corruptedPayload));
     }

--- a/PocketMC.Desktop.Tests/DataProtectorTests.cs
+++ b/PocketMC.Desktop.Tests/DataProtectorTests.cs
@@ -1,0 +1,30 @@
+using System.Security.Cryptography;
+using PocketMC.Desktop.Infrastructure.Security;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class DataProtectorTests
+{
+    [Fact]
+    public void Protect_RoundTrips_WithVersionedPayload()
+    {
+        string protectedValue = DataProtector.Protect("secret-value");
+
+        Assert.StartsWith("dpapi:v1:", protectedValue, StringComparison.Ordinal);
+        Assert.Equal("secret-value", DataProtector.Unprotect(protectedValue));
+    }
+
+    [Fact]
+    public void Unprotect_ReturnsLegacyPlaintext_WhenValueIsNotBase64()
+    {
+        Assert.Equal("legacy-secret", DataProtector.Unprotect("legacy-secret"));
+    }
+
+    [Fact]
+    public void Unprotect_Throws_WhenBase64PayloadCannotBeDecrypted()
+    {
+        string corruptedPayload = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+        Assert.Throws<CryptographicException>(() => DataProtector.Unprotect(corruptedPayload));
+    }
+}

--- a/PocketMC.Desktop.Tests/DiskWriteSafetyTests.cs
+++ b/PocketMC.Desktop.Tests/DiskWriteSafetyTests.cs
@@ -1,0 +1,32 @@
+namespace PocketMC.Desktop.Tests;
+
+public sealed class DiskWriteSafetyTests
+{
+    [Theory]
+    [InlineData(
+        new[] { "PocketMC.Desktop", "Features", "Intelligence", "SummaryStorageService.cs" },
+        "File.WriteAllText(filePath",
+        "FileUtils.AtomicWriteAllText(filePath")]
+    [InlineData(
+        new[] { "PocketMC.Desktop", "Features", "Instances", "Backups", "BackupMetadata.cs" },
+        "File.WriteAllText(path",
+        "FileUtils.AtomicWriteAllText(path")]
+    [InlineData(
+        new[] { "PocketMC.Desktop", "Features", "Marketplace", "AddonManifestService.cs" },
+        "File.WriteAllTextAsync(path",
+        "FileUtils.AtomicWriteAllTextAsync(path")]
+    [InlineData(
+        new[] { "PocketMC.Desktop", "Features", "Tunnel", "PlayitAgentService.cs" },
+        "File.WriteAllText(tomlPath",
+        "FileUtils.AtomicWriteAllText(tomlPath")]
+    public void PersistentStateWriters_UseAtomicFileReplacement(
+        string[] sourcePath,
+        string unsafeWriteCall,
+        string expectedAtomicWriteCall)
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(sourcePath));
+
+        Assert.DoesNotContain(unsafeWriteCall, source);
+        Assert.Contains(expectedAtomicWriteCall, source);
+    }
+}

--- a/PocketMC.Desktop.Tests/JavaRuntimeValidatorTests.cs
+++ b/PocketMC.Desktop.Tests/JavaRuntimeValidatorTests.cs
@@ -1,0 +1,18 @@
+namespace PocketMC.Desktop.Tests;
+
+public sealed class JavaRuntimeValidatorTests
+{
+    [Fact]
+    public void ValidateRuntimeAsync_KillsJavaProcessTreeWhenValidationIsCanceled()
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(
+            "PocketMC.Desktop",
+            "Features",
+            "Java",
+            "JavaRuntimeValidator.cs"));
+
+        Assert.Contains("catch (OperationCanceledException", source, StringComparison.Ordinal);
+        Assert.Contains("process.Kill(entireProcessTree: true)", source, StringComparison.Ordinal);
+        Assert.Contains("throw new TimeoutException", source, StringComparison.Ordinal);
+    }
+}

--- a/PocketMC.Desktop.Tests/JobObjectTests.cs
+++ b/PocketMC.Desktop.Tests/JobObjectTests.cs
@@ -1,0 +1,20 @@
+using PocketMC.Desktop.Infrastructure;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class JobObjectTests
+{
+    [Fact]
+    public void AddProcess_ThrowsObjectDisposedException_AfterDispose()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var jobObject = new JobObject();
+        jobObject.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => jobObject.AddProcess(IntPtr.Zero));
+    }
+}

--- a/PocketMC.Desktop.Tests/MarketplaceDownloadPathSafetyTests.cs
+++ b/PocketMC.Desktop.Tests/MarketplaceDownloadPathSafetyTests.cs
@@ -1,0 +1,28 @@
+namespace PocketMC.Desktop.Tests;
+
+public sealed class MarketplaceDownloadPathSafetyTests
+{
+    [Theory]
+    [InlineData(
+        new[] { "PocketMC.Desktop", "Features", "Marketplace", "PluginBrowserPage.xaml.cs" },
+        "Path.Combine(destDir, fileName)",
+        "MarketplaceFileNameSanitizer.RequireSafeFileName(fileName)")]
+    [InlineData(
+        new[] { "PocketMC.Desktop", "Features", "Marketplace", "MapBrowserPage.xaml.cs" },
+        "Path.Combine(Path.GetTempPath(), file.FileName)",
+        "MarketplaceFileNameSanitizer.RequireSafeFileName(file.FileName)")]
+    [InlineData(
+        new[] { "PocketMC.Desktop", "Features", "Marketplace", "AddonUpdateService.cs" },
+        "Path.Combine(destDir, updateInfo.LatestFileName)",
+        "MarketplaceFileNameSanitizer.RequireSafeFileName(updateInfo.LatestFileName)")]
+    public void MarketplaceDownloadWriters_NormalizeProviderFileNamesBeforeCombiningPaths(
+        string[] sourcePath,
+        string unsafePathCombine,
+        string expectedSanitizerCall)
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(sourcePath));
+
+        Assert.DoesNotContain(unsafePathCombine, source);
+        Assert.Contains(expectedSanitizerCall, source);
+    }
+}

--- a/PocketMC.Desktop.Tests/MarketplaceFileNameSanitizerTests.cs
+++ b/PocketMC.Desktop.Tests/MarketplaceFileNameSanitizerTests.cs
@@ -19,6 +19,13 @@ public sealed class MarketplaceFileNameSanitizerTests
     [InlineData("   ")]
     [InlineData(".")]
     [InlineData("..")]
+    [InlineData("CON")]
+    [InlineData("CON.jar")]
+    [InlineData("NUL.zip")]
+    [InlineData("LPT1.jar")]
+    [InlineData("mod.jar ")]
+    [InlineData("mod.jar.")]
+    [InlineData("server.jar:ads")]
     public void RequireSafeFileName_ThrowsForInvalidLeafNames(string input)
     {
         Assert.Throws<InvalidOperationException>(() => MarketplaceFileNameSanitizer.RequireSafeFileName(input));

--- a/PocketMC.Desktop.Tests/MarketplaceFileNameSanitizerTests.cs
+++ b/PocketMC.Desktop.Tests/MarketplaceFileNameSanitizerTests.cs
@@ -1,0 +1,26 @@
+using PocketMC.Desktop.Features.Marketplace;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class MarketplaceFileNameSanitizerTests
+{
+    [Theory]
+    [InlineData("mod.jar", "mod.jar")]
+    [InlineData("folder/mod.jar", "mod.jar")]
+    [InlineData("..\\outside.jar", "outside.jar")]
+    [InlineData("C:\\Temp\\outside.jar", "outside.jar")]
+    public void RequireSafeFileName_ReturnsLeafName(string input, string expected)
+    {
+        Assert.Equal(expected, MarketplaceFileNameSanitizer.RequireSafeFileName(input));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void RequireSafeFileName_ThrowsForInvalidLeafNames(string input)
+    {
+        Assert.Throws<InvalidOperationException>(() => MarketplaceFileNameSanitizer.RequireSafeFileName(input));
+    }
+}

--- a/PocketMC.Desktop.Tests/PathSafetyTests.cs
+++ b/PocketMC.Desktop.Tests/PathSafetyTests.cs
@@ -24,6 +24,8 @@ public sealed class PathSafetyTests
     [InlineData("mods/..\\..\\..\\escape.exe", true)]
     [InlineData("mods/server.jar:evil", true)]
     [InlineData("C:\\Windows\\system32\\drivers\\etc\\hosts", true)]
+    [InlineData("\\\\?\\C:\\Windows\\system32\\drivers\\etc\\hosts", true)]
+    [InlineData("//server/share/file.txt", true)]
     public void ContainsTraversal_DetectsEscapeAttempts(string path, bool shouldBeTraversal)
     {
         Assert.Equal(shouldBeTraversal, PathSafety.ContainsTraversal(path));
@@ -60,6 +62,8 @@ public sealed class PathSafetyTests
     [Theory]
     [InlineData("mods/server.jar:payload")]
     [InlineData("C:\\Windows\\system32\\drivers\\etc\\hosts")]
+    [InlineData("\\\\?\\C:\\Windows\\system32\\drivers\\etc\\hosts")]
+    [InlineData("//server/share/file.txt")]
     public void ValidateContainedPath_ReturnsNull_ForWindowsSpecialPaths(string path)
     {
         string root = Path.Combine(Path.GetTempPath(), "test-root");

--- a/PocketMC.Desktop.Tests/PathSafetyTests.cs
+++ b/PocketMC.Desktop.Tests/PathSafetyTests.cs
@@ -22,6 +22,8 @@ public sealed class PathSafetyTests
     [InlineData("mods/../../../escape.dll", true)]
     [InlineData("..\\windows\\system32\\evil.dll", true)]
     [InlineData("mods/..\\..\\..\\escape.exe", true)]
+    [InlineData("mods/server.jar:evil", true)]
+    [InlineData("C:\\Windows\\system32\\drivers\\etc\\hosts", true)]
     public void ContainsTraversal_DetectsEscapeAttempts(string path, bool shouldBeTraversal)
     {
         Assert.Equal(shouldBeTraversal, PathSafety.ContainsTraversal(path));
@@ -53,5 +55,14 @@ public sealed class PathSafetyTests
 
         Assert.NotNull(result);
         Assert.Contains("advanced", result!);
+    }
+
+    [Theory]
+    [InlineData("mods/server.jar:payload")]
+    [InlineData("C:\\Windows\\system32\\drivers\\etc\\hosts")]
+    public void ValidateContainedPath_ReturnsNull_ForWindowsSpecialPaths(string path)
+    {
+        string root = Path.Combine(Path.GetTempPath(), "test-root");
+        Assert.Null(PathSafety.ValidateContainedPath(root, path));
     }
 }

--- a/PocketMC.Desktop.Tests/PortPreflightServiceTests.cs
+++ b/PocketMC.Desktop.Tests/PortPreflightServiceTests.cs
@@ -249,6 +249,19 @@ public sealed class PortPreflightServiceTests
         Assert.Contains("\r\n", updated);
     }
 
+    [Fact]
+    public void SimpleVoiceChatConfigService_UsesAtomicWrites_ForConfigMutations()
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(
+            "PocketMC.Desktop",
+            "Features",
+            "Networking",
+            "SimpleVoiceChatProperties.cs"));
+
+        Assert.DoesNotContain("File.WriteAllText(configPath", source);
+        Assert.Contains("FileUtils.AtomicWriteAllText(configPath", source);
+    }
+
     private static int CountOccurrences(string value, string needle)
     {
         int count = 0;

--- a/PocketMC.Desktop.Tests/RconClientTests.cs
+++ b/PocketMC.Desktop.Tests/RconClientTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Net.Sockets;
+using PocketMC.Desktop.Infrastructure.Process;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class RconClientTests
+{
+    [Fact]
+    public async Task ConnectAsync_RejectsOversizedResponseLength()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient accepted = await listener.AcceptTcpClientAsync();
+            await using NetworkStream stream = accepted.GetStream();
+
+            byte[] requestLengthBuffer = new byte[4];
+            await ReadExactAsync(stream, requestLengthBuffer);
+            int requestLength = BitConverter.ToInt32(requestLengthBuffer, 0);
+            byte[] requestBody = new byte[requestLength];
+            await ReadExactAsync(stream, requestBody);
+
+            byte[] maliciousLength = BitConverter.GetBytes(1024 * 1024 + 1);
+            await stream.WriteAsync(maliciousLength);
+        });
+
+        using var client = new RconClient("127.0.0.1", port, "password");
+
+        await Assert.ThrowsAsync<InvalidDataException>(() => client.ConnectAsync());
+        await serverTask;
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer)
+    {
+        int offset = 0;
+        while (offset < buffer.Length)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(offset));
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            offset += read;
+        }
+    }
+}

--- a/PocketMC.Desktop.Tests/RegexTimeoutSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/RegexTimeoutSecurityTests.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using PocketMC.Desktop.Features.Intelligence;
+using PocketMC.Desktop.Features.Networking;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class RegexTimeoutSecurityTests
+{
+    [Theory]
+    [InlineData(typeof(SessionLogPreprocessor))]
+    [InlineData(typeof(SimpleVoiceChatDetector))]
+    public void ParserRegexes_UseFiniteMatchTimeouts(Type parserType)
+    {
+        foreach (Regex regex in GetRegexFields(parserType))
+        {
+            Assert.NotEqual(Regex.InfiniteMatchTimeout, regex.MatchTimeout);
+        }
+    }
+
+    private static IEnumerable<Regex> GetRegexFields(Type type)
+    {
+        foreach (FieldInfo field in type.GetFields(BindingFlags.Static | BindingFlags.NonPublic))
+        {
+            object? value = field.GetValue(null);
+            if (value is Regex regex)
+            {
+                yield return regex;
+            }
+            else if (value is IEnumerable<Regex> regexes)
+            {
+                foreach (Regex item in regexes)
+                {
+                    yield return item;
+                }
+            }
+        }
+    }
+}

--- a/PocketMC.Desktop.Tests/RegexTimeoutSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/RegexTimeoutSecurityTests.cs
@@ -1,13 +1,19 @@
 using System.Reflection;
 using System.Text.RegularExpressions;
+using PocketMC.Desktop.Features.CloudBackups;
+using PocketMC.Desktop.Features.Instances.Backups;
 using PocketMC.Desktop.Features.Intelligence;
 using PocketMC.Desktop.Features.Networking;
+using PocketMC.Desktop.Features.Tunnel;
 
 namespace PocketMC.Desktop.Tests;
 
 public sealed class RegexTimeoutSecurityTests
 {
     [Theory]
+    [InlineData(typeof(CloudPathSanitizer))]
+    [InlineData(typeof(BackupService))]
+    [InlineData(typeof(PlayitAgentService))]
     [InlineData(typeof(SessionLogPreprocessor))]
     [InlineData(typeof(SimpleVoiceChatDetector))]
     public void ParserRegexes_UseFiniteMatchTimeouts(Type parserType)
@@ -16,6 +22,19 @@ public sealed class RegexTimeoutSecurityTests
         {
             Assert.NotEqual(Regex.InfiniteMatchTimeout, regex.MatchTimeout);
         }
+    }
+
+    [Fact]
+    public void PlayitAgentService_UsesBoundedRegexForLegacyTomlImport()
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(
+            "PocketMC.Desktop",
+            "Features",
+            "Tunnel",
+            "PlayitAgentService.cs"));
+
+        Assert.DoesNotContain("Match match = Regex.Match(content", source);
+        Assert.Contains("LegacyTomlSecretRegex.Match(content)", source);
     }
 
     private static IEnumerable<Regex> GetRegexFields(Type type)

--- a/PocketMC.Desktop.Tests/SafeZipExtractorTests.cs
+++ b/PocketMC.Desktop.Tests/SafeZipExtractorTests.cs
@@ -36,6 +36,24 @@ public sealed class SafeZipExtractorTests : IDisposable
         Assert.False(File.Exists(Path.Combine(_tempDirectory, "outside.txt")));
     }
 
+    [Fact]
+    public async Task ExtractAsync_Throws_WhenZipEntryTargetsAlternateDataStream()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        string zipPath = Path.Combine(_tempDirectory, "ads.zip");
+        string extractPath = Path.Combine(_tempDirectory, "extract");
+
+        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry("server.properties:secret");
+            await using var stream = entry.Open();
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteAsync("not allowed");
+        }
+
+        await Assert.ThrowsAsync<InvalidDataException>(() => SafeZipExtractor.ExtractAsync(zipPath, extractPath));
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))

--- a/PocketMC.Desktop.Tests/ServerLifecycleServiceTests.cs
+++ b/PocketMC.Desktop.Tests/ServerLifecycleServiceTests.cs
@@ -70,4 +70,19 @@ public sealed class ServerLifecycleServiceTests
         Assert.Empty(leaseRegistry.GetLeasesForInstance(metadata.Id));
         Assert.Null(workspace.AppState.GetTunnelAddress(metadata.Id));
     }
+
+    [Fact]
+    public void CrashEventHandler_LogsCancellationSeparatelyFromUnexpectedFailures()
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(
+            "PocketMC.Desktop",
+            "Features",
+            "Instances",
+            "Services",
+            "ServerLifecycleService.cs"));
+
+        Assert.Contains("catch (OperationCanceledException)", source, StringComparison.Ordinal);
+        Assert.Contains("Crash recovery was cancelled for instance {InstanceId}.", source, StringComparison.Ordinal);
+        Assert.Contains("Unhandled error while processing crash recovery for instance {InstanceId}.", source, StringComparison.Ordinal);
+    }
 }

--- a/PocketMC.Desktop.Tests/SettingsManagerSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/SettingsManagerSecurityTests.cs
@@ -1,0 +1,44 @@
+using PocketMC.Desktop.Features.CloudBackups;
+using PocketMC.Desktop.Features.Settings;
+using PocketMC.Desktop.Models;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class SettingsManagerSecurityTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), "PocketMC.Tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Save_EncryptsCloudOAuthTokensBeforeSerializingSettings()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        string settingsPath = Path.Combine(_tempDirectory, "settings.json");
+        var manager = new SettingsManager(settingsPath);
+        var settings = new AppSettings();
+        settings.CloudTokens["GoogleDrive"] = new CloudOAuthTokenSet
+        {
+            Provider = CloudBackupProviderType.GoogleDrive,
+            AccessToken = "access-token-plain",
+            RefreshToken = "refresh-token-plain"
+        };
+
+        manager.Save(settings);
+
+        string persisted = File.ReadAllText(settingsPath);
+        Assert.DoesNotContain("access-token-plain", persisted, StringComparison.Ordinal);
+        Assert.DoesNotContain("refresh-token-plain", persisted, StringComparison.Ordinal);
+        Assert.Contains("dpapi:v1:", persisted, StringComparison.Ordinal);
+
+        AppSettings loaded = manager.Load();
+        Assert.Equal("access-token-plain", loaded.CloudTokens["GoogleDrive"].AccessToken);
+        Assert.Equal("refresh-token-plain", loaded.CloudTokens["GoogleDrive"].RefreshToken);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/PocketMC.Desktop.Tests/SettingsManagerSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/SettingsManagerSecurityTests.cs
@@ -1,6 +1,8 @@
 using PocketMC.Desktop.Features.CloudBackups;
 using PocketMC.Desktop.Features.Settings;
 using PocketMC.Desktop.Models;
+using System.Security.Cryptography;
+using System.Text.Json;
 
 namespace PocketMC.Desktop.Tests;
 
@@ -32,6 +34,68 @@ public sealed class SettingsManagerSecurityTests : IDisposable
         AppSettings loaded = manager.Load();
         Assert.Equal("access-token-plain", loaded.CloudTokens["GoogleDrive"].AccessToken);
         Assert.Equal("refresh-token-plain", loaded.CloudTokens["GoogleDrive"].RefreshToken);
+    }
+
+    [Fact]
+    public void Load_ClearsOnlyCorruptedProtectedSecretAndPreservesOtherSettings()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        string settingsPath = Path.Combine(_tempDirectory, "settings.json");
+        var settings = new AppSettings
+        {
+            AppRootPath = @"D:\PocketMC\Instances",
+            CurseForgeApiKey = CreateCorruptedProtectedPayload(),
+            WindowBackdrop = "Mica",
+            EnableAiSummarization = true
+        };
+        settings.AiApiKeys["Gemini"] = "plain-gemini-key";
+        File.WriteAllText(settingsPath, JsonSerializer.Serialize(settings));
+
+        AppSettings loaded = new SettingsManager(settingsPath).Load();
+
+        Assert.Null(loaded.CurseForgeApiKey);
+        Assert.Equal(@"D:\PocketMC\Instances", loaded.AppRootPath);
+        Assert.Equal("Mica", loaded.WindowBackdrop);
+        Assert.True(loaded.EnableAiSummarization);
+        Assert.Equal("plain-gemini-key", loaded.AiApiKeys["Gemini"]);
+    }
+
+    [Fact]
+    public void Load_RemovesOnlyCloudTokenProviderWhenProtectedTokenCannotDecrypt()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        string settingsPath = Path.Combine(_tempDirectory, "settings.json");
+        var settings = new AppSettings
+        {
+            AppRootPath = @"D:\PocketMC\Instances",
+            WindowBackdrop = "Mica"
+        };
+        settings.CloudTokens["GoogleDrive"] = new CloudOAuthTokenSet
+        {
+            Provider = CloudBackupProviderType.GoogleDrive,
+            AccessToken = CreateCorruptedProtectedPayload(),
+            RefreshToken = "refresh-token-plain"
+        };
+        settings.CloudTokens["OneDrive"] = new CloudOAuthTokenSet
+        {
+            Provider = CloudBackupProviderType.OneDrive,
+            AccessToken = "one-access-token",
+            RefreshToken = "one-refresh-token"
+        };
+        File.WriteAllText(settingsPath, JsonSerializer.Serialize(settings));
+
+        AppSettings loaded = new SettingsManager(settingsPath).Load();
+
+        Assert.False(loaded.CloudTokens.ContainsKey("GoogleDrive"));
+        Assert.True(loaded.CloudTokens.ContainsKey("OneDrive"));
+        Assert.Equal("one-access-token", loaded.CloudTokens["OneDrive"].AccessToken);
+        Assert.Equal(@"D:\PocketMC\Instances", loaded.AppRootPath);
+        Assert.Equal("Mica", loaded.WindowBackdrop);
+    }
+
+    private static string CreateCorruptedProtectedPayload()
+    {
+        return "dpapi:v1:" + Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
     }
 
     public void Dispose()

--- a/PocketMC.Desktop.Tests/SettingsManagerSecurityTests.cs
+++ b/PocketMC.Desktop.Tests/SettingsManagerSecurityTests.cs
@@ -93,6 +93,24 @@ public sealed class SettingsManagerSecurityTests : IDisposable
         Assert.Equal("Mica", loaded.WindowBackdrop);
     }
 
+    [Fact]
+    public void Load_RemovesNullCloudTokenEntriesFromMalformedSettings()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        string settingsPath = Path.Combine(_tempDirectory, "settings.json");
+        File.WriteAllText(settingsPath, """
+        {
+          "CloudTokens": {
+            "GoogleDrive": null
+          }
+        }
+        """);
+
+        AppSettings loaded = new SettingsManager(settingsPath).Load();
+
+        Assert.Empty(loaded.CloudTokens);
+    }
+
     private static string CreateCorruptedProtectedPayload()
     {
         return "dpapi:v1:" + Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));

--- a/PocketMC.Desktop.Tests/SummaryStorageServiceTests.cs
+++ b/PocketMC.Desktop.Tests/SummaryStorageServiceTests.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using PocketMC.Desktop.Features.Intelligence;
+using PocketMC.Desktop.Models;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class SummaryStorageServiceTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "PocketMC_SummaryTests_" + Guid.NewGuid());
+    private readonly SummaryStorageService _service = new();
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup for temp files.
+        }
+    }
+
+    [Fact]
+    public void Read_ReturnsNull_WhenFileNameEscapesSummaryDirectory()
+    {
+        string serverDir = Path.Combine(_root, "server");
+        Directory.CreateDirectory(serverDir);
+
+        string outsidePath = Path.Combine(_root, "outside-summary.json");
+        File.WriteAllText(outsidePath, JsonSerializer.Serialize(CreateSummary("outside")));
+
+        SessionSummary? summary = _service.Read(serverDir, Path.Combine("..", "..", "outside-summary.json"));
+
+        Assert.Null(summary);
+    }
+
+    [Fact]
+    public void Delete_ReturnsFalseAndDoesNotDelete_WhenFileNameEscapesSummaryDirectory()
+    {
+        string serverDir = Path.Combine(_root, "server");
+        Directory.CreateDirectory(serverDir);
+
+        string outsidePath = Path.Combine(_root, "outside-summary.json");
+        File.WriteAllText(outsidePath, JsonSerializer.Serialize(CreateSummary("outside")));
+
+        bool deleted = _service.Delete(serverDir, Path.Combine("..", "..", "outside-summary.json"));
+
+        Assert.False(deleted);
+        Assert.True(File.Exists(outsidePath));
+    }
+
+    [Fact]
+    public void Save_StillPersistsAndListsContainedSummary()
+    {
+        string serverDir = Path.Combine(_root, "server");
+
+        string path = _service.Save(serverDir, CreateSummary("contained"));
+
+        Assert.True(File.Exists(path));
+        SessionSummary summary = Assert.Single(_service.ListSummaries(serverDir));
+        Assert.Equal("contained", summary.Content);
+    }
+
+    private static SessionSummary CreateSummary(string content)
+    {
+        return new SessionSummary
+        {
+            ServerName = "Test",
+            SessionStart = DateTime.UtcNow.AddMinutes(-5),
+            SessionEnd = DateTime.UtcNow,
+            Duration = TimeSpan.FromMinutes(5),
+            Content = content,
+            AiProvider = "Test"
+        };
+    }
+}

--- a/PocketMC.Desktop.Tests/UwpLoopbackHelperTests.cs
+++ b/PocketMC.Desktop.Tests/UwpLoopbackHelperTests.cs
@@ -1,0 +1,18 @@
+namespace PocketMC.Desktop.Tests;
+
+public sealed class UwpLoopbackHelperTests
+{
+    [Fact]
+    public void IsExemptionPresent_UsesAsyncProcessWaitWithTimeout()
+    {
+        string source = File.ReadAllText(TestSourceFileResolver.Resolve(
+            "PocketMC.Desktop",
+            "Infrastructure",
+            "UwpLoopbackHelper.cs"));
+
+        Assert.DoesNotContain("StandardOutput.ReadToEnd()", source);
+        Assert.DoesNotContain("proc.WaitForExit();", source);
+        Assert.Contains("RedirectStandardError = true", source);
+        Assert.Contains("WaitForExitAsync(cts.Token)", source);
+    }
+}

--- a/PocketMC.Desktop/Composition/ServiceCollectionExtensions.cs
+++ b/PocketMC.Desktop/Composition/ServiceCollectionExtensions.cs
@@ -97,7 +97,6 @@ namespace PocketMC.Desktop.Composition
             services.AddSingleton<PortFailureMessageService>();
 
             services.AddSingleton<IResourceMonitorService, ResourceMonitorService>();
-            services.AddSingleton(provider => (ResourceMonitorService)provider.GetRequiredService<IResourceMonitorService>());
             services.AddSingleton<BackupService>();
             services.AddSingleton<BackupSchedulerService>();
 

--- a/PocketMC.Desktop/Features/CloudBackups/CloudPathSanitizer.cs
+++ b/PocketMC.Desktop/Features/CloudBackups/CloudPathSanitizer.cs
@@ -5,7 +5,12 @@ namespace PocketMC.Desktop.Features.CloudBackups;
 
 public static class CloudPathSanitizer
 {
-    private static readonly Regex InvalidCharsRegex = new Regex(@"[<>:""/\\|?*]", RegexOptions.Compiled);
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    private static readonly Regex InvalidCharsRegex = new(
+        @"[<>:""/\\|?*]",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexTimeout);
     
     public static string SanitizeFolderName(string input)
     {

--- a/PocketMC.Desktop/Features/CloudBackups/OAuth/LoopbackOAuthReceiver.cs
+++ b/PocketMC.Desktop/Features/CloudBackups/OAuth/LoopbackOAuthReceiver.cs
@@ -8,7 +8,10 @@ namespace PocketMC.Desktop.Features.CloudBackups.OAuth;
 
 public class LoopbackOAuthReceiver
 {
-    public async Task<(string? code, string? error)> ReceiveCodeAsync(string redirectUri, CancellationToken ct)
+    public async Task<(string? code, string? error)> ReceiveCodeAsync(
+        string redirectUri,
+        CancellationToken ct,
+        string? expectedState = null)
     {
         using var listener = new HttpListener();
         listener.Prefixes.Add(redirectUri);
@@ -23,10 +26,18 @@ public class LoopbackOAuthReceiver
 
             string? code = request.QueryString.Get("code");
             string? error = request.QueryString.Get("error");
+            string? state = request.QueryString.Get("state");
+
+            if (!string.IsNullOrEmpty(expectedState) &&
+                !string.Equals(state, expectedState, StringComparison.Ordinal))
+            {
+                code = null;
+                error = "invalid_state";
+            }
 
             string responseString = string.IsNullOrEmpty(error) 
                 ? "<html><body><h2>Authentication successful!</h2><p>You can close this tab and return to PocketMC.</p></body></html>"
-                : $"<html><body><h2>Authentication failed</h2><p>Error: {error}</p><p>You can close this tab.</p></body></html>";
+                : $"<html><body><h2>Authentication failed</h2><p>Error: {WebUtility.HtmlEncode(error)}</p><p>You can close this tab.</p></body></html>";
 
             byte[] buffer = Encoding.UTF8.GetBytes(responseString);
             response.ContentLength64 = buffer.Length;

--- a/PocketMC.Desktop/Features/CloudBackups/Providers/DropboxBackupProvider.cs
+++ b/PocketMC.Desktop/Features/CloudBackups/Providers/DropboxBackupProvider.cs
@@ -123,7 +123,7 @@ public class DropboxBackupProvider : ICloudBackupProvider
         System.Diagnostics.Process.Start(psi);
 
         var receiver = new LoopbackOAuthReceiver();
-        var (code, error) = await receiver.ReceiveCodeAsync(RedirectUri + "/", ct);
+        var (code, error) = await receiver.ReceiveCodeAsync(RedirectUri + "/", ct, state);
 
         if (!string.IsNullOrEmpty(error)) throw new Exception($"Dropbox Auth Error: {error}");
         if (string.IsNullOrEmpty(code)) throw new Exception("No code returned.");

--- a/PocketMC.Desktop/Features/CloudBackups/Providers/GoogleDriveBackupProvider.cs
+++ b/PocketMC.Desktop/Features/CloudBackups/Providers/GoogleDriveBackupProvider.cs
@@ -150,7 +150,7 @@ public class GoogleDriveBackupProvider : ICloudBackupProvider
         System.Diagnostics.Process.Start(psi);
 
         var receiver = new LoopbackOAuthReceiver();
-        var (code, error) = await receiver.ReceiveCodeAsync(RedirectUri + "/", ct);
+        var (code, error) = await receiver.ReceiveCodeAsync(RedirectUri + "/", ct, state);
 
         if (!string.IsNullOrEmpty(error)) throw new Exception($"Google Auth Error: {error}");
         if (string.IsNullOrEmpty(code)) throw new Exception("No code returned.");

--- a/PocketMC.Desktop/Features/Instances/Backups/BackupMetadata.cs
+++ b/PocketMC.Desktop/Features/Instances/Backups/BackupMetadata.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using PocketMC.Desktop.Infrastructure.FileSystem;
+using PocketMC.Desktop.Infrastructure.Security;
 
 namespace PocketMC.Desktop.Features.Instances.Backups;
 
@@ -102,7 +104,7 @@ public class BackupManifest
         if (dir != null) Directory.CreateDirectory(dir);
 
         var json = JsonSerializer.Serialize(this, JsonOptions);
-        File.WriteAllText(path, json);
+        FileUtils.AtomicWriteAllText(path, json);
     }
 
     /// <summary>
@@ -122,8 +124,18 @@ public class BackupManifest
         var backupDir = Path.Combine(serverDir, "backups");
         Entries.RemoveAll(e =>
         {
-            var zipPath = Path.Combine(backupDir, e.FileName);
+            string? zipPath = ResolveBackupFilePath(backupDir, e.FileName);
             return !File.Exists(zipPath);
         });
+    }
+
+    private static string? ResolveBackupFilePath(string backupDir, string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName) || Path.GetFileName(fileName) != fileName)
+        {
+            return null;
+        }
+
+        return PathSafety.ValidateContainedPath(backupDir, fileName);
     }
 }

--- a/PocketMC.Desktop/Features/Instances/Backups/BackupService.cs
+++ b/PocketMC.Desktop/Features/Instances/Backups/BackupService.cs
@@ -32,7 +32,8 @@ public class BackupService
 {
     private static readonly Regex SaveCompletedRegex = new(
         @"(saved the game|saved the world|saved chunks|saved all chunks|all dimensions are saved|world saved)",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
 
     private readonly ServerProcessManager _serverProcessManager;
     private readonly ServerConfigurationService _configService;
@@ -187,11 +188,22 @@ public class BackupService
 
         if (entry?.Sha256Checksum == null) return null;
 
-        var zipPath = Path.Combine(serverDir, "backups", fileName);
-        if (!File.Exists(zipPath)) return false;
+        string? zipPath = ResolveBackupFilePath(serverDir, fileName);
+        if (zipPath == null || !File.Exists(zipPath)) return false;
 
         var currentHash = ComputeSha256(zipPath);
         return string.Equals(entry.Sha256Checksum, currentHash, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? ResolveBackupFilePath(string serverDir, string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName) || Path.GetFileName(fileName) != fileName)
+        {
+            return null;
+        }
+
+        string backupDir = Path.Combine(serverDir, "backups");
+        return PathSafety.ValidateContainedPath(backupDir, fileName);
     }
 
     private async Task<LocalBackupResult> CreateLocalBackupAsync(InstanceMetadata metadata, string serverDir, Action<string>? onProgress)

--- a/PocketMC.Desktop/Features/Instances/Backups/SafeZipExtractor.cs
+++ b/PocketMC.Desktop/Features/Instances/Backups/SafeZipExtractor.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using PocketMC.Desktop.Infrastructure.Security;
 
 namespace PocketMC.Desktop.Features.Instances.Backups
 {
@@ -25,8 +26,8 @@ namespace PocketMC.Desktop.Features.Instances.Backups
 
                 foreach (var entry in archive.Entries)
                 {
-                    string destinationPath = Path.GetFullPath(Path.Combine(extractRoot, entry.FullName));
-                    if (!destinationPath.StartsWith(extractRoot, StringComparison.OrdinalIgnoreCase))
+                    string? destinationPath = PathSafety.ValidateContainedPath(extractRoot, entry.FullName);
+                    if (destinationPath == null)
                     {
                         throw new InvalidDataException($"ZIP entry '{entry.FullName}' would extract outside the destination directory.");
                     }

--- a/PocketMC.Desktop/Features/Instances/Services/ServerLifecycleService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/ServerLifecycleService.cs
@@ -252,7 +252,14 @@ public class ServerLifecycleService : IServerLifecycleService, IDisposable
 
     private async void HandleProcessManagerServerCrashed(Guid instanceId, string _)
     {
-        await HandleServerCrashAsync(instanceId);
+        try
+        {
+            await HandleServerCrashAsync(instanceId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled error while processing crash recovery for instance {InstanceId}.", instanceId);
+        }
     }
 
     private async Task HandleServerCrashAsync(Guid instanceId)

--- a/PocketMC.Desktop/Features/Instances/Services/ServerLifecycleService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/ServerLifecycleService.cs
@@ -256,6 +256,10 @@ public class ServerLifecycleService : IServerLifecycleService, IDisposable
         {
             await HandleServerCrashAsync(instanceId);
         }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("Crash recovery was cancelled for instance {InstanceId}.", instanceId);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unhandled error while processing crash recovery for instance {InstanceId}.", instanceId);

--- a/PocketMC.Desktop/Features/Intelligence/SessionLogPreprocessor.cs
+++ b/PocketMC.Desktop/Features/Intelligence/SessionLogPreprocessor.cs
@@ -12,37 +12,39 @@ namespace PocketMC.Desktop.Features.Intelligence;
 /// </summary>
 public static class SessionLogPreprocessor
 {
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
     // Lines matching these patterns are noise and should be removed
     private static readonly Regex[] NoisePatterns = new[]
     {
-        new Regex(@"\[DEBUG\]", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new Regex(@"Can't keep up! Is the server overloaded\?", RegexOptions.Compiled),
-        new Regex(@"moved too quickly!", RegexOptions.Compiled),
-        new Regex(@"Preparing spawn area:", RegexOptions.Compiled),
-        new Regex(@"Loaded \d+ recipes", RegexOptions.Compiled),
-        new Regex(@"Loaded \d+ advancements", RegexOptions.Compiled),
-        new Regex(@"UUID of player", RegexOptions.Compiled),
-        new Regex(@"com\.mojang\.authlib", RegexOptions.Compiled),
-        new Regex(@"LoginListener", RegexOptions.Compiled),
-        new Regex(@"Chunk stats", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        CreateRegex(@"\[DEBUG\]", RegexOptions.IgnoreCase),
+        CreateRegex(@"Can't keep up! Is the server overloaded\?"),
+        CreateRegex(@"moved too quickly!"),
+        CreateRegex(@"Preparing spawn area:"),
+        CreateRegex(@"Loaded \d+ recipes"),
+        CreateRegex(@"Loaded \d+ advancements"),
+        CreateRegex(@"UUID of player"),
+        CreateRegex(@"com\.mojang\.authlib"),
+        CreateRegex(@"LoginListener"),
+        CreateRegex(@"Chunk stats", RegexOptions.IgnoreCase),
     };
 
     // Lines matching these are important and should always be kept
     private static readonly Regex[] ImportantPatterns = new[]
     {
-        new Regex(@"joined the game", RegexOptions.Compiled),
-        new Regex(@"left the game", RegexOptions.Compiled),
-        new Regex(@"was (slain|shot|blown|killed|drowned|burnt|squashed|fell|withered|poked|fireballed|stung|starved|suffocated|squished|impaled|frozen|struck)", RegexOptions.Compiled),
-        new Regex(@"\[Server\]", RegexOptions.Compiled),
-        new Regex(@"issued server command:", RegexOptions.Compiled),
-        new Regex(@"has (made the|completed) advancement", RegexOptions.Compiled),
-        new Regex(@"has reached the goal", RegexOptions.Compiled),
-        new Regex(@"(Stopping|Starting|Done \()", RegexOptions.Compiled),
-        new Regex(@"(ERROR|WARN|FATAL)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new Regex(@"(kicked|banned|whitelisted|opped|de-opped)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new Regex(@"Teleported", RegexOptions.Compiled),
-        new Regex(@"lost connection:", RegexOptions.Compiled),
-        new Regex(@"(challenge|has completed)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        CreateRegex(@"joined the game"),
+        CreateRegex(@"left the game"),
+        CreateRegex(@"was (slain|shot|blown|killed|drowned|burnt|squashed|fell|withered|poked|fireballed|stung|starved|suffocated|squished|impaled|frozen|struck)"),
+        CreateRegex(@"\[Server\]"),
+        CreateRegex(@"issued server command:"),
+        CreateRegex(@"has (made the|completed) advancement"),
+        CreateRegex(@"has reached the goal"),
+        CreateRegex(@"(Stopping|Starting|Done \()"),
+        CreateRegex(@"(ERROR|WARN|FATAL)", RegexOptions.IgnoreCase),
+        CreateRegex(@"(kicked|banned|whitelisted|opped|de-opped)", RegexOptions.IgnoreCase),
+        CreateRegex(@"Teleported"),
+        CreateRegex(@"lost connection:"),
+        CreateRegex(@"(challenge|has completed)", RegexOptions.IgnoreCase),
     };
 
     /// <summary>
@@ -57,7 +59,13 @@ public static class SessionLogPreprocessor
 
     private static readonly Regex IpRegex = new(
         @"\b(?:\d{1,3}\.){3}\d{1,3}\b|\b(?:[a-fA-F0-9]{1,4}:){2,7}[a-fA-F0-9]{1,4}\b",
-        RegexOptions.Compiled);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexTimeout);
+
+    private static Regex CreateRegex(string pattern, RegexOptions options = RegexOptions.None)
+    {
+        return new Regex(pattern, options | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
+    }
 
     /// <summary>
     /// Process raw log lines into a cleaner, AI-friendly format.

--- a/PocketMC.Desktop/Features/Intelligence/SummaryStorageService.cs
+++ b/PocketMC.Desktop/Features/Intelligence/SummaryStorageService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using PocketMC.Desktop.Infrastructure.FileSystem;
+using PocketMC.Desktop.Infrastructure.Security;
 using PocketMC.Desktop.Models;
 
 namespace PocketMC.Desktop.Features.Intelligence;
@@ -40,7 +42,7 @@ public class SummaryStorageService
         }
 
         var json = JsonSerializer.Serialize(summary, new JsonSerializerOptions { WriteIndented = true });
-        File.WriteAllText(filePath, json);
+        FileUtils.AtomicWriteAllText(filePath, json);
         return filePath;
     }
 
@@ -81,7 +83,8 @@ public class SummaryStorageService
     /// </summary>
     public SessionSummary? Read(string serverDir, string fileName)
     {
-        var filePath = Path.Combine(serverDir, SummariesFolder, fileName);
+        string? filePath = ResolveSummaryFilePath(serverDir, fileName);
+        if (filePath == null) return null;
         if (!File.Exists(filePath)) return null;
 
         try
@@ -100,7 +103,8 @@ public class SummaryStorageService
     /// </summary>
     public bool Delete(string serverDir, string fileName)
     {
-        var filePath = Path.Combine(serverDir, SummariesFolder, fileName);
+        string? filePath = ResolveSummaryFilePath(serverDir, fileName);
+        if (filePath == null) return false;
         if (!File.Exists(filePath)) return false;
 
         try
@@ -122,5 +126,16 @@ public class SummaryStorageService
         var dir = Path.Combine(serverDir, SummariesFolder);
         if (!Directory.Exists(dir)) return 0;
         return Directory.GetFiles(dir, "summary_*.json").Length;
+    }
+
+    private static string? ResolveSummaryFilePath(string serverDir, string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName) || Path.GetFileName(fileName) != fileName)
+        {
+            return null;
+        }
+
+        string summaryDir = Path.Combine(serverDir, SummariesFolder);
+        return PathSafety.ValidateContainedPath(summaryDir, fileName);
     }
 }

--- a/PocketMC.Desktop/Features/Java/JavaRuntimeValidator.cs
+++ b/PocketMC.Desktop/Features/Java/JavaRuntimeValidator.cs
@@ -62,12 +62,40 @@ namespace PocketMC.Desktop.Features.Java
 
             Task<string> stdOutTask = process.StandardOutput.ReadToEndAsync(cts.Token);
             Task<string> stdErrTask = process.StandardError.ReadToEndAsync(cts.Token);
-            await process.WaitForExitAsync(cts.Token);
-            await Task.WhenAll(stdOutTask, stdErrTask);
+            try
+            {
+                await process.WaitForExitAsync(cts.Token);
+                await Task.WhenAll(stdOutTask, stdErrTask);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                KillTimedOutProcess(process);
+                throw new TimeoutException("Java validation timed out.");
+            }
+            catch (OperationCanceledException)
+            {
+                KillTimedOutProcess(process);
+                throw;
+            }
 
             if (process.ExitCode != 0)
             {
                 throw new InvalidOperationException($"Java validation failed (Exit Code: {process.ExitCode}): {stdErrTask.Result}");
+            }
+        }
+
+        private void KillTimedOutProcess(Process process)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to kill timed-out Java validation process.");
             }
         }
     }

--- a/PocketMC.Desktop/Features/Java/JavaRuntimeValidator.cs
+++ b/PocketMC.Desktop/Features/Java/JavaRuntimeValidator.cs
@@ -60,12 +60,14 @@ namespace PocketMC.Desktop.Features.Java
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(15));
 
+            Task<string> stdOutTask = process.StandardOutput.ReadToEndAsync(cts.Token);
+            Task<string> stdErrTask = process.StandardError.ReadToEndAsync(cts.Token);
             await process.WaitForExitAsync(cts.Token);
+            await Task.WhenAll(stdOutTask, stdErrTask);
 
             if (process.ExitCode != 0)
             {
-                string stdErr = await process.StandardError.ReadToEndAsync();
-                throw new InvalidOperationException($"Java validation failed (Exit Code: {process.ExitCode}): {stdErr}");
+                throw new InvalidOperationException($"Java validation failed (Exit Code: {process.ExitCode}): {stdErrTask.Result}");
             }
         }
     }

--- a/PocketMC.Desktop/Features/Marketplace/AddonManifestService.cs
+++ b/PocketMC.Desktop/Features/Marketplace/AddonManifestService.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using PocketMC.Desktop.Infrastructure.FileSystem;
+using PocketMC.Desktop.Infrastructure.Security;
 using PocketMC.Desktop.Models;
 
 namespace PocketMC.Desktop.Features.Marketplace
@@ -69,12 +70,13 @@ namespace PocketMC.Desktop.Features.Marketplace
         {
             string path = Path.Combine(serverDir, ManifestFileName);
             string json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
-            await File.WriteAllTextAsync(path, json);
+            await FileUtils.AtomicWriteAllTextAsync(path, json);
         }
 
         public async Task RegisterInstallAsync(string serverDir, string provider, string projectId, string versionId, string fileName)
         {
             var manifest = await LoadManifestAsync(serverDir);
+            string safeFileName = MarketplaceFileNameSanitizer.RequireSafeFileName(fileName);
             
             // Remove any existing entry for this project to avoid duplicates (effectively an "update")
             manifest.Entries.RemoveAll(e => e.ProjectId == projectId && e.Provider == provider);
@@ -84,7 +86,7 @@ namespace PocketMC.Desktop.Features.Marketplace
                 Provider = provider,
                 ProjectId = projectId,
                 VersionId = versionId,
-                FileName = fileName,
+                FileName = safeFileName,
                 InstalledAt = DateTime.UtcNow
             });
 
@@ -118,9 +120,9 @@ namespace PocketMC.Desktop.Features.Marketplace
             if (entry == null) return false;
 
             // Verify file still exists on disk
-            string filePath = Path.Combine(serverDir, compat.PrimaryAddonSubDir, entry.FileName);
+            string? filePath = ResolveAddonFilePath(serverDir, compat.PrimaryAddonSubDir, entry.FileName);
             
-            if (!File.Exists(filePath))
+            if (filePath == null || !File.Exists(filePath))
             {
                 // Auto-cleanup stale manifest entry
                 await UnregisterAsync(serverDir, provider, projectId);
@@ -143,8 +145,8 @@ namespace PocketMC.Desktop.Features.Marketplace
                 string subDir = (entry.FileName.EndsWith(".phar") || entry.FileName.EndsWith(".php")) ? "plugins" : 
                                 (entry.FileName.EndsWith(".mcpack") || entry.FileName.EndsWith(".mcaddon")) ? "behavior_packs" : "mods";
                 
-                string filePath = Path.Combine(serverDir, subDir, entry.FileName);
-                if (!File.Exists(filePath))
+                string? filePath = ResolveAddonFilePath(serverDir, subDir, entry.FileName);
+                if (filePath == null || !File.Exists(filePath))
                 {
                     entriesToRemove.Add(entry);
                 }
@@ -227,6 +229,17 @@ namespace PocketMC.Desktop.Features.Marketplace
             var sb = new StringBuilder();
             foreach (var b in hashBytes) sb.Append(b.ToString("x2"));
             return sb.ToString();
+        }
+
+        private static string? ResolveAddonFilePath(string serverDir, string subDir, string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName) || Path.GetFileName(fileName) != fileName)
+            {
+                return null;
+            }
+
+            string addonDir = Path.Combine(serverDir, subDir);
+            return PathSafety.ValidateContainedPath(addonDir, fileName);
         }
     }
 }

--- a/PocketMC.Desktop/Features/Marketplace/AddonUpdateService.cs
+++ b/PocketMC.Desktop/Features/Marketplace/AddonUpdateService.cs
@@ -146,11 +146,13 @@ namespace PocketMC.Desktop.Features.Marketplace
             if (updateInfo.LatestDownloadUrl == null || updateInfo.LatestFileName == null)
                 throw new InvalidOperationException("Update info is incomplete — missing download URL or filename.");
 
+            string safeLatestFileName = MarketplaceFileNameSanitizer.RequireSafeFileName(updateInfo.LatestFileName);
+
             string destDir = Path.Combine(serverDir, compat.PrimaryAddonSubDir);
             if (!Directory.Exists(destDir)) Directory.CreateDirectory(destDir);
 
             // Download new file
-            string newFilePath = Path.Combine(destDir, updateInfo.LatestFileName);
+            string newFilePath = Path.Combine(destDir, safeLatestFileName);
 
             using var httpClient = _httpClientFactory.CreateClient("PocketMC.Downloads");
             using var response = await httpClient.GetAsync(updateInfo.LatestDownloadUrl, HttpCompletionOption.ResponseHeadersRead);
@@ -163,9 +165,10 @@ namespace PocketMC.Desktop.Features.Marketplace
             }
 
             // Delete old file if it has a different name
-            if (!string.Equals(oldFileName, updateInfo.LatestFileName, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(oldFileName, safeLatestFileName, StringComparison.OrdinalIgnoreCase))
             {
-                string oldFilePath = Path.Combine(destDir, oldFileName);
+                string safeOldFileName = MarketplaceFileNameSanitizer.RequireSafeFileName(oldFileName);
+                string oldFilePath = Path.Combine(destDir, safeOldFileName);
                 if (File.Exists(oldFilePath))
                 {
                     try { File.Delete(oldFilePath); } catch { /* Best-effort cleanup */ }
@@ -175,7 +178,7 @@ namespace PocketMC.Desktop.Features.Marketplace
             // Update manifest entry
             await _manifestService.RegisterInstallAsync(
                 serverDir, providerName, projectId,
-                updateInfo.LatestVersionId ?? "", updateInfo.LatestFileName);
+                updateInfo.LatestVersionId ?? "", safeLatestFileName);
         }
 
         private IAddonProvider? GetProvider(string providerName)

--- a/PocketMC.Desktop/Features/Marketplace/MapBrowserPage.xaml.cs
+++ b/PocketMC.Desktop/Features/Marketplace/MapBrowserPage.xaml.cs
@@ -154,7 +154,8 @@ namespace PocketMC.Desktop.Features.Marketplace
                 using var response = await httpClient.GetAsync(file.Url, HttpCompletionOption.ResponseHeadersRead);
                 response.EnsureSuccessStatusCode();
 
-                string destFile = Path.Combine(Path.GetTempPath(), file.FileName);
+                string safeFileName = MarketplaceFileNameSanitizer.RequireSafeFileName(file.FileName);
+                string destFile = Path.Combine(Path.GetTempPath(), safeFileName);
 
                 await using (var contentStream = await response.Content.ReadAsStreamAsync())
                 await using (var fileStream = new FileStream(destFile, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true))

--- a/PocketMC.Desktop/Features/Marketplace/MarketplaceFileNameSanitizer.cs
+++ b/PocketMC.Desktop/Features/Marketplace/MarketplaceFileNameSanitizer.cs
@@ -1,10 +1,37 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace PocketMC.Desktop.Features.Marketplace;
 
 public static class MarketplaceFileNameSanitizer
 {
+    private static readonly HashSet<string> ReservedWindowsNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "COM5",
+        "COM6",
+        "COM7",
+        "COM8",
+        "COM9",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "LPT4",
+        "LPT5",
+        "LPT6",
+        "LPT7",
+        "LPT8",
+        "LPT9"
+    };
+
     public static string RequireSafeFileName(string fileName)
     {
         if (string.IsNullOrWhiteSpace(fileName))
@@ -15,13 +42,23 @@ public static class MarketplaceFileNameSanitizer
         string normalized = fileName.Replace('\\', '/');
         int slashIndex = normalized.LastIndexOf('/');
         string leafName = slashIndex >= 0 ? normalized[(slashIndex + 1)..] : normalized;
+        string trimmedLeafName = leafName.Trim();
 
         if (string.IsNullOrWhiteSpace(leafName) ||
+            trimmedLeafName.Length != leafName.Length ||
+            leafName.EndsWith(".", StringComparison.Ordinal) ||
+            leafName.Contains(':', StringComparison.Ordinal) ||
             leafName == "." ||
             leafName == ".." ||
             leafName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
         {
             throw new InvalidOperationException("Marketplace file name is invalid.");
+        }
+
+        string nameWithoutExtension = Path.GetFileNameWithoutExtension(leafName);
+        if (ReservedWindowsNames.Contains(nameWithoutExtension))
+        {
+            throw new InvalidOperationException("Marketplace file name uses a reserved Windows device name.");
         }
 
         return leafName;

--- a/PocketMC.Desktop/Features/Marketplace/MarketplaceFileNameSanitizer.cs
+++ b/PocketMC.Desktop/Features/Marketplace/MarketplaceFileNameSanitizer.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+
+namespace PocketMC.Desktop.Features.Marketplace;
+
+public static class MarketplaceFileNameSanitizer
+{
+    public static string RequireSafeFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new InvalidOperationException("Marketplace file name is missing.");
+        }
+
+        string normalized = fileName.Replace('\\', '/');
+        int slashIndex = normalized.LastIndexOf('/');
+        string leafName = slashIndex >= 0 ? normalized[(slashIndex + 1)..] : normalized;
+
+        if (string.IsNullOrWhiteSpace(leafName) ||
+            leafName == "." ||
+            leafName == ".." ||
+            leafName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new InvalidOperationException("Marketplace file name is invalid.");
+        }
+
+        return leafName;
+    }
+}

--- a/PocketMC.Desktop/Features/Marketplace/PluginBrowserPage.xaml.cs
+++ b/PocketMC.Desktop/Features/Marketplace/PluginBrowserPage.xaml.cs
@@ -305,6 +305,7 @@ namespace PocketMC.Desktop.Features.Marketplace
         private async Task InstallSingleFileAsync(string url, string fileName, string providerName, string projectId, string versionId)
         {
             if (_serverDir == null && !_isModpackMode) return;
+            string safeFileName = MarketplaceFileNameSanitizer.RequireSafeFileName(fileName);
 
             using var httpClient = _httpClientFactory.CreateClient("PocketMC.Downloads");
             using var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
@@ -313,13 +314,13 @@ namespace PocketMC.Desktop.Features.Marketplace
             string destFile;
             if (_isModpackMode)
             {
-                destFile = Path.Combine(Path.GetTempPath(), fileName);
+                destFile = Path.Combine(Path.GetTempPath(), safeFileName);
             }
             else
             {
                 string destDir = Path.Combine(_serverDir!, _compat.PrimaryAddonSubDir);
                 if (!Directory.Exists(destDir)) Directory.CreateDirectory(destDir);
-                destFile = Path.Combine(destDir, fileName);
+                destFile = Path.Combine(destDir, safeFileName);
             }
 
             await using (var contentStream = await response.Content.ReadAsStreamAsync())
@@ -338,7 +339,7 @@ namespace PocketMC.Desktop.Features.Marketplace
             // Register in manifest if not modpack
             if (_serverDir != null)
             {
-                await _manifestService.RegisterInstallAsync(_serverDir, providerName, projectId, versionId, fileName);
+                await _manifestService.RegisterInstallAsync(_serverDir, providerName, projectId, versionId, safeFileName);
             }
         }
     }

--- a/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
+++ b/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
@@ -93,7 +93,7 @@ public sealed class BedrockAddonInstaller : IAddonManager
         }
     }
 
-    public Task UninstallAsync(string addonPathOrId, string serverDir, CancellationToken ct = default)
+    public async Task UninstallAsync(string addonPathOrId, string serverDir, CancellationToken ct = default)
     {
         // Uninstall = delete the pack directory from behavior_packs / resource_packs
         // and scrub the UUID from the world JSON files.
@@ -103,6 +103,11 @@ public sealed class BedrockAddonInstaller : IAddonManager
 
         foreach (var subDir in new[] { BehaviorPacksDir, ResourcePacksDir })
         {
+            if (Path.IsPathRooted(subDir))
+            {
+                throw new InvalidOperationException($"Bedrock add-on pack directory '{subDir}' must be relative.");
+            }
+
             string packsRoot = Path.Combine(serverDir, subDir);
             string? candidate = PathSafety.ValidateContainedPath(packsRoot, addonPathOrId);
             if (candidate == null)
@@ -117,7 +122,7 @@ public sealed class BedrockAddonInstaller : IAddonManager
                 // Try to read UUID from the manifest so we can scrub the world JSON.
                 var mPath = Path.Combine(candidate, "manifest.json");
                 if (File.Exists(mPath))
-                    packUuid = TryReadUuid(mPath);
+                    packUuid = await TryReadUuidAsync(mPath, ct);
                 break;
             }
         }
@@ -125,7 +130,8 @@ public sealed class BedrockAddonInstaller : IAddonManager
         if (packDir == null)
             throw new DirectoryNotFoundException($"Pack directory not found for id '{addonPathOrId}'.");
 
-        Directory.Delete(packDir, recursive: true);
+        ct.ThrowIfCancellationRequested();
+        await Task.Run(() => Directory.Delete(packDir, recursive: true), ct);
         _logger.LogInformation("Deleted pack directory {Dir}.", packDir);
 
         if (packUuid != null)
@@ -135,10 +141,8 @@ public sealed class BedrockAddonInstaller : IAddonManager
                 ? Path.Combine(worldDir, WorldBehaviorJson)
                 : Path.Combine(worldDir, WorldResourceJson);
 
-            RemoveFromWorldJson(jsonFile, packUuid);
+            await RemoveFromWorldJsonAsync(jsonFile, packUuid, ct);
         }
-
-        return Task.CompletedTask;
     }
 
     // ── Core installation logic ────────────────────────────────────────────
@@ -224,6 +228,26 @@ public sealed class BedrockAddonInstaller : IAddonManager
         catch { return null; }
     }
 
+    private static async Task<string?> TryReadUuidAsync(string manifestPath, CancellationToken ct)
+    {
+        try
+        {
+            await using var stream = new FileStream(
+                manifestPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete,
+                bufferSize: 4096,
+                useAsync: true);
+            var doc = await JsonNode.ParseAsync(stream, cancellationToken: ct);
+            return doc?["header"]?["uuid"]?.GetValue<string>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     // ── World JSON management ─────────────────────────────────────────────
 
     private void RegisterInWorldJson(string jsonFilePath, string uuid, string version)
@@ -281,6 +305,43 @@ public sealed class BedrockAddonInstaller : IAddonManager
             var options = new JsonSerializerOptions { WriteIndented = true };
             FileUtils.AtomicWriteAllText(jsonFilePath, entries.ToJsonString(options));
             _logger.LogInformation("Removed UUID {Uuid} from {File}.", uuid, Path.GetFileName(jsonFilePath));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to scrub UUID {Uuid} from {File}.", uuid, jsonFilePath);
+        }
+    }
+
+    private async Task RemoveFromWorldJsonAsync(string jsonFilePath, string uuid, CancellationToken ct)
+    {
+        if (!File.Exists(jsonFilePath)) return;
+        try
+        {
+            JsonArray entries;
+            await using (var stream = new FileStream(
+                jsonFilePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete,
+                bufferSize: 4096,
+                useAsync: true))
+            {
+                entries = await JsonNode.ParseAsync(stream, cancellationToken: ct) as JsonArray ?? new JsonArray();
+            }
+
+            for (int i = entries.Count - 1; i >= 0; i--)
+            {
+                if (entries[i]?["pack_id"]?.GetValue<string>() == uuid)
+                    entries.RemoveAt(i);
+            }
+
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            await FileUtils.AtomicWriteAllTextAsync(jsonFilePath, entries.ToJsonString(options), cancellationToken: ct);
+            _logger.LogInformation("Removed UUID {Uuid} from {File}.", uuid, Path.GetFileName(jsonFilePath));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
+++ b/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
@@ -246,6 +246,7 @@ public sealed class BedrockAddonInstaller : IAddonManager
         catch (IOException) { return null; }
         catch (UnauthorizedAccessException) { return null; }
         catch (JsonException) { return null; }
+        catch (InvalidOperationException) { return null; }
         catch (NotSupportedException) { return null; }
     }
 

--- a/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
+++ b/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
@@ -8,6 +8,9 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using PocketMC.Desktop.Features.Instances.Backups;
+using PocketMC.Desktop.Infrastructure.FileSystem;
+using PocketMC.Desktop.Infrastructure.Security;
 
 namespace PocketMC.Desktop.Features.Mods;
 
@@ -68,7 +71,7 @@ public sealed class BedrockAddonInstaller : IAddonManager
         {
             Directory.CreateDirectory(tempDir);
             _logger.LogInformation("Extracting addon {File} to temp dir {TempDir}.", sourceFilePath, tempDir);
-            await Task.Run(() => ZipFile.ExtractToDirectory(sourceFilePath, tempDir, overwriteFiles: true), ct);
+            await SafeZipExtractor.ExtractAsync(sourceFilePath, tempDir);
 
             var manifests = FindManifests(tempDir);
             if (manifests.Count == 0)
@@ -100,7 +103,13 @@ public sealed class BedrockAddonInstaller : IAddonManager
 
         foreach (var subDir in new[] { BehaviorPacksDir, ResourcePacksDir })
         {
-            string candidate = Path.Combine(serverDir, subDir, addonPathOrId);
+            string packsRoot = Path.Combine(serverDir, subDir);
+            string? candidate = PathSafety.ValidateContainedPath(packsRoot, addonPathOrId);
+            if (candidate == null)
+            {
+                continue;
+            }
+
             if (Directory.Exists(candidate))
             {
                 packDir  = candidate;
@@ -149,11 +158,13 @@ public sealed class BedrockAddonInstaller : IAddonManager
 
         // The pack root dir is the directory that contains this manifest.json.
         string packSourceDir = Path.GetDirectoryName(manifestPath)!;
-        string packName = SanitizeDirName(manifest.Name ?? manifest.Uuid);
+        string packName = BuildPackDirectoryName(manifest);
 
         bool isBehavior = manifest.PackType == PackType.Data;
         string targetSubDir = isBehavior ? BehaviorPacksDir : ResourcePacksDir;
-        string packDestDir  = Path.Combine(serverDir, targetSubDir, packName);
+        string packsRoot = Path.Combine(serverDir, targetSubDir);
+        string packDestDir = PathSafety.ValidateContainedPath(packsRoot, packName)
+            ?? throw new InvalidOperationException($"Invalid Bedrock add-on pack directory name '{packName}'.");
 
         _logger.LogInformation(
             "Installing {Type} pack '{Name}' (uuid={Uuid}) → {Dest}.",
@@ -183,6 +194,8 @@ public sealed class BedrockAddonInstaller : IAddonManager
 
         string uuid = doc["header"]?["uuid"]?.GetValue<string>()
             ?? throw new KeyNotFoundException("manifest.json is missing header.uuid.");
+        if (!Guid.TryParse(uuid, out _))
+            throw new JsonException("manifest.json header.uuid is not a valid UUID.");
 
         // Version is stored as an array e.g. [1, 0, 0]
         string version = "1.0.0";
@@ -251,7 +264,7 @@ public sealed class BedrockAddonInstaller : IAddonManager
         entries.Add(newEntry);
 
         var options = new JsonSerializerOptions { WriteIndented = true };
-        File.WriteAllText(jsonFilePath, entries.ToJsonString(options));
+        FileUtils.AtomicWriteAllText(jsonFilePath, entries.ToJsonString(options));
     }
 
     private void RemoveFromWorldJson(string jsonFilePath, string uuid)
@@ -266,7 +279,7 @@ public sealed class BedrockAddonInstaller : IAddonManager
                     entries.RemoveAt(i);
             }
             var options = new JsonSerializerOptions { WriteIndented = true };
-            File.WriteAllText(jsonFilePath, entries.ToJsonString(options));
+            FileUtils.AtomicWriteAllText(jsonFilePath, entries.ToJsonString(options));
             _logger.LogInformation("Removed UUID {Uuid} from {File}.", uuid, Path.GetFileName(jsonFilePath));
         }
         catch (Exception ex)
@@ -346,8 +359,22 @@ public sealed class BedrockAddonInstaller : IAddonManager
             CopyDirectory(subDir, Path.Combine(dest, Path.GetFileName(subDir)));
     }
 
+    private static string BuildPackDirectoryName(ManifestInfo manifest)
+    {
+        string rawName = !string.IsNullOrWhiteSpace(manifest.Name) ? manifest.Name! : manifest.Uuid;
+        string packName = SanitizeDirName(rawName);
+        if (string.IsNullOrWhiteSpace(packName))
+        {
+            throw new InvalidOperationException("Bedrock add-on manifest produced an empty pack directory name.");
+        }
+
+        return packName;
+    }
+
     private static string SanitizeDirName(string name) =>
-        string.Concat(name.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c)).Trim();
+        string.Concat(name.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c))
+            .Trim()
+            .TrimEnd('.');
 
     private static int[] ParseVersionParts(string version)
     {

--- a/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
+++ b/PocketMC.Desktop/Features/Mods/BedrockAddonInstaller.cs
@@ -166,7 +166,8 @@ public sealed class BedrockAddonInstaller : IAddonManager
 
         bool isBehavior = manifest.PackType == PackType.Data;
         string targetSubDir = isBehavior ? BehaviorPacksDir : ResourcePacksDir;
-        string packsRoot = Path.Combine(serverDir, targetSubDir);
+        string? packsRoot = PathSafety.ValidateContainedPath(serverDir, targetSubDir)
+            ?? throw new InvalidOperationException($"Bedrock add-on pack directory '{targetSubDir}' must be relative.");
         string packDestDir = PathSafety.ValidateContainedPath(packsRoot, packName)
             ?? throw new InvalidOperationException($"Invalid Bedrock add-on pack directory name '{packName}'.");
 
@@ -242,10 +243,10 @@ public sealed class BedrockAddonInstaller : IAddonManager
             var doc = await JsonNode.ParseAsync(stream, cancellationToken: ct);
             return doc?["header"]?["uuid"]?.GetValue<string>();
         }
-        catch
-        {
-            return null;
-        }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (JsonException) { return null; }
+        catch (NotSupportedException) { return null; }
     }
 
     // ── World JSON management ─────────────────────────────────────────────

--- a/PocketMC.Desktop/Features/Networking/SimpleVoiceChatProperties.cs
+++ b/PocketMC.Desktop/Features/Networking/SimpleVoiceChatProperties.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using PocketMC.Desktop.Infrastructure.FileSystem;
 
 namespace PocketMC.Desktop.Features.Networking;
 
@@ -32,9 +33,12 @@ public sealed record SimpleVoiceChatDetection(
 
 public static class SimpleVoiceChatDetector
 {
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
     private static readonly Regex VoiceChatStartedRegex = new(
         @"\[voicechat\]\s+Voice chat server started at port\s+(?<port>\d+)",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexTimeout);
 
     public static SimpleVoiceChatDetection Detect(string? serverDir)
     {
@@ -206,6 +210,7 @@ public static class SimpleVoiceChatConfigService
     public const int DefaultPort = 24454;
     public const string DefaultBindAddress = "*";
     private const string StableNewline = "\r\n";
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
 
     public static string DetectConfigPath(string instancePath)
     {
@@ -267,7 +272,7 @@ public static class SimpleVoiceChatConfigService
             "bind_address=*",
             $"voice_host={voiceHost}",
             string.Empty);
-        File.WriteAllText(configPath, content);
+        FileUtils.AtomicWriteAllText(configPath, content);
         return configPath;
     }
 
@@ -390,7 +395,7 @@ public static class SimpleVoiceChatConfigService
             return false;
         }
 
-        File.WriteAllText(configPath, string.Join(newline, lines) + (hadFinalNewline ? newline : string.Empty));
+        FileUtils.AtomicWriteAllText(configPath, string.Join(newline, lines) + (hadFinalNewline ? newline : string.Empty));
         return true;
     }
 
@@ -549,7 +554,7 @@ public static class SimpleVoiceChatConfigService
 
     private static string[] SplitLines(string text)
     {
-        string[] lines = Regex.Split(text, "\r\n|\n|\r");
+        string[] lines = Regex.Split(text, "\r\n|\n|\r", RegexOptions.CultureInvariant, RegexTimeout);
         if (lines.Length > 0 && lines[^1].Length == 0 && EndsWithNewline(text))
         {
             return lines[..^1];

--- a/PocketMC.Desktop/Features/Settings/SettingsManager.cs
+++ b/PocketMC.Desktop/Features/Settings/SettingsManager.cs
@@ -181,6 +181,13 @@ namespace PocketMC.Desktop.Features.Settings
             settings ??= new AppSettings();
             settings.AiApiKeys ??= new System.Collections.Generic.Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             settings.CloudTokens ??= new System.Collections.Generic.Dictionary<string, CloudOAuthTokenSet>(StringComparer.OrdinalIgnoreCase);
+            foreach (var key in new System.Collections.Generic.List<string>(settings.CloudTokens.Keys))
+            {
+                if (settings.CloudTokens[key] == null)
+                {
+                    settings.CloudTokens.Remove(key);
+                }
+            }
             settings.UserRemovedJavaVersions ??= new System.Collections.Generic.HashSet<int>();
             settings.CloudBackups ??= new CloudBackupSettings();
             settings.PlayitConfigDirectory ??= Path.Combine(

--- a/PocketMC.Desktop/Features/Settings/SettingsManager.cs
+++ b/PocketMC.Desktop/Features/Settings/SettingsManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using PocketMC.Desktop.Models;
@@ -40,60 +41,21 @@ namespace PocketMC.Desktop.Features.Settings
                 return CreateDefaultSettings();
             }
 
+            AppSettings? settings;
             try
             {
                 var content = File.ReadAllText(_settingsFilePath);
-                var settings = JsonSerializer.Deserialize<AppSettings>(content);
-                if (settings != null)
-                {
-                    if (!string.IsNullOrEmpty(settings.CurseForgeApiKey))
-                    {
-                        settings.CurseForgeApiKey = DataProtector.Unprotect(settings.CurseForgeApiKey);
-                    }
-
-                    if (!string.IsNullOrEmpty(settings.PlayitPartnerConnection?.AgentSecretKey))
-                    {
-                        settings.PlayitPartnerConnection.AgentSecretKey =
-                            DataProtector.Unprotect(settings.PlayitPartnerConnection.AgentSecretKey);
-                    }
-
-                    if (settings.AiApiKeys != null)
-                    {
-                        foreach (var key in new System.Collections.Generic.List<string>(settings.AiApiKeys.Keys))
-                        {
-                            if (!string.IsNullOrEmpty(settings.AiApiKeys[key]))
-                            {
-                                settings.AiApiKeys[key] = DataProtector.Unprotect(settings.AiApiKeys[key]);
-                            }
-                        }
-                    }
-
-                    if (settings.CloudTokens != null)
-                    {
-                        foreach (var key in new System.Collections.Generic.List<string>(settings.CloudTokens.Keys))
-                        {
-                            var tokenSet = settings.CloudTokens[key];
-                            if (tokenSet != null)
-                            {
-                                if (!string.IsNullOrEmpty(tokenSet.AccessToken))
-                                {
-                                    tokenSet.AccessToken = DataProtector.Unprotect(tokenSet.AccessToken);
-                                }
-                                if (!string.IsNullOrEmpty(tokenSet.RefreshToken))
-                                {
-                                    tokenSet.RefreshToken = DataProtector.Unprotect(tokenSet.RefreshToken);
-                                }
-                            }
-                        }
-                    }
-                }
-                return Normalize(settings);
+                settings = JsonSerializer.Deserialize<AppSettings>(content);
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "Failed to load settings from {SettingsFilePath}. Falling back to defaults.", _settingsFilePath);
                 return CreateDefaultSettings();
             }
+
+            settings = Normalize(settings);
+            UnprotectSecrets(settings);
+            return settings;
         }
 
         public void Save(AppSettings settings)
@@ -217,6 +179,10 @@ namespace PocketMC.Desktop.Features.Settings
         private AppSettings Normalize(AppSettings? settings)
         {
             settings ??= new AppSettings();
+            settings.AiApiKeys ??= new System.Collections.Generic.Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            settings.CloudTokens ??= new System.Collections.Generic.Dictionary<string, CloudOAuthTokenSet>(StringComparer.OrdinalIgnoreCase);
+            settings.UserRemovedJavaVersions ??= new System.Collections.Generic.HashSet<int>();
+            settings.CloudBackups ??= new CloudBackupSettings();
             settings.PlayitConfigDirectory ??= Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "playit_gg");
@@ -231,6 +197,95 @@ namespace PocketMC.Desktop.Features.Settings
             }
 
             return settings;
+        }
+
+        private void UnprotectSecrets(AppSettings settings)
+        {
+            settings.CurseForgeApiKey = TryUnprotectSetting(settings.CurseForgeApiKey, nameof(settings.CurseForgeApiKey));
+
+            if (settings.PlayitPartnerConnection != null)
+            {
+                settings.PlayitPartnerConnection.AgentSecretKey = TryUnprotectSetting(
+                    settings.PlayitPartnerConnection.AgentSecretKey,
+                    $"{nameof(settings.PlayitPartnerConnection)}.{nameof(settings.PlayitPartnerConnection.AgentSecretKey)}");
+            }
+
+            foreach (var key in new System.Collections.Generic.List<string>(settings.AiApiKeys.Keys))
+            {
+                string? unprotected = TryUnprotectSetting(settings.AiApiKeys[key], $"AiApiKeys.{key}");
+                if (unprotected == null && !string.IsNullOrEmpty(settings.AiApiKeys[key]))
+                {
+                    settings.AiApiKeys.Remove(key);
+                    continue;
+                }
+
+                settings.AiApiKeys[key] = unprotected ?? string.Empty;
+            }
+
+            foreach (var key in new System.Collections.Generic.List<string>(settings.CloudTokens.Keys))
+            {
+                var tokenSet = settings.CloudTokens[key];
+                if (tokenSet == null || !TryUnprotectCloudTokenSet(tokenSet, key))
+                {
+                    settings.CloudTokens.Remove(key);
+                }
+            }
+        }
+
+        private string? TryUnprotectSetting(string? value, string settingName)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            try
+            {
+                return DataProtector.Unprotect(value);
+            }
+            catch (CryptographicException ex)
+            {
+                _logger?.LogWarning(ex, "Failed to decrypt protected setting {SettingName}. Clearing only that value.", settingName);
+                return null;
+            }
+        }
+
+        private bool TryUnprotectCloudTokenSet(CloudOAuthTokenSet tokenSet, string providerName)
+        {
+            if (!TryUnprotectCloudToken(tokenSet.AccessToken, $"{nameof(AppSettings.CloudTokens)}.{providerName}.{nameof(tokenSet.AccessToken)}", out var accessToken))
+            {
+                return false;
+            }
+
+            if (!TryUnprotectCloudToken(tokenSet.RefreshToken, $"{nameof(AppSettings.CloudTokens)}.{providerName}.{nameof(tokenSet.RefreshToken)}", out var refreshToken))
+            {
+                return false;
+            }
+
+            tokenSet.AccessToken = accessToken;
+            tokenSet.RefreshToken = refreshToken;
+            return true;
+        }
+
+        private bool TryUnprotectCloudToken(string? value, string settingName, out string? unprotected)
+        {
+            unprotected = value;
+            if (string.IsNullOrEmpty(value))
+            {
+                return true;
+            }
+
+            try
+            {
+                unprotected = DataProtector.Unprotect(value);
+                return true;
+            }
+            catch (CryptographicException ex)
+            {
+                _logger?.LogWarning(ex, "Failed to decrypt protected setting {SettingName}. Removing that cloud token provider.", settingName);
+                unprotected = null;
+                return false;
+            }
         }
     }
 }

--- a/PocketMC.Desktop/Features/Settings/SettingsManager.cs
+++ b/PocketMC.Desktop/Features/Settings/SettingsManager.cs
@@ -22,6 +22,17 @@ namespace PocketMC.Desktop.Features.Settings
                 "settings.json");
         }
 
+        public SettingsManager(string settingsFilePath, ILogger<SettingsManager>? logger = null)
+        {
+            if (string.IsNullOrWhiteSpace(settingsFilePath))
+            {
+                throw new ArgumentException("Settings file path cannot be empty.", nameof(settingsFilePath));
+            }
+
+            _logger = logger;
+            _settingsFilePath = settingsFilePath;
+        }
+
         public AppSettings Load()
         {
             if (!File.Exists(_settingsFilePath))
@@ -137,7 +148,6 @@ namespace PocketMC.Desktop.Features.Settings
                     }
                 }
 
-                var content = JsonSerializer.Serialize(normalizedSettings, new JsonSerializerOptions { WriteIndented = true });
                 if (normalizedSettings.CloudTokens != null)
                 {
                     foreach (var kvp in normalizedSettings.CloudTokens)
@@ -157,6 +167,7 @@ namespace PocketMC.Desktop.Features.Settings
                     }
                 }
 
+                var content = JsonSerializer.Serialize(normalizedSettings, new JsonSerializerOptions { WriteIndented = true });
                 FileUtils.AtomicWriteAllText(_settingsFilePath, content);
             }
             finally

--- a/PocketMC.Desktop/Features/Shell/ShellStartupCoordinator.cs
+++ b/PocketMC.Desktop/Features/Shell/ShellStartupCoordinator.cs
@@ -23,7 +23,7 @@ namespace PocketMC.Desktop.Features.Shell
         private readonly IServerLifecycleService _serverLifecycleService;
         private readonly JavaProvisioningService _javaProvisioningService;
         private readonly PlayitAgentService _playitAgentService;
-        private readonly ResourceMonitorService _resourceMonitorService;
+        private readonly IResourceMonitorService _resourceMonitorService;
         private readonly PocketMC.Desktop.Features.Diagnostics.DependencyHealthMonitor _healthMonitor;
         private readonly ILogger<ShellStartupCoordinator> _logger;
         private IStartupShellHost? _host;
@@ -38,7 +38,7 @@ namespace PocketMC.Desktop.Features.Shell
             IServerLifecycleService serverLifecycleService,
             JavaProvisioningService javaProvisioningService,
             PlayitAgentService playitAgentService,
-            ResourceMonitorService resourceMonitorService,
+            IResourceMonitorService resourceMonitorService,
             PocketMC.Desktop.Features.Diagnostics.DependencyHealthMonitor healthMonitor,
             ILogger<ShellStartupCoordinator> logger)
         {

--- a/PocketMC.Desktop/Features/Tunnel/PlayitAgentService.cs
+++ b/PocketMC.Desktop/Features/Tunnel/PlayitAgentService.cs
@@ -36,6 +36,11 @@ namespace PocketMC.Desktop.Features.Tunnel
             @"tunnel running",
             RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
 
+        private static readonly Regex LegacyTomlSecretRegex = new(
+            @"secret_key\s*=\s*""([^""]+)""",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant,
+            TimeSpan.FromSeconds(1));
+
         private readonly PlayitAgentProcessManager _processManager;
         private readonly PlayitAgentStateMachine _stateMachine;
         private readonly ApplicationState _applicationState;
@@ -352,7 +357,7 @@ namespace PocketMC.Desktop.Features.Tunnel
             try
             {
                 string content = File.ReadAllText(tomlPath);
-                Match match = Regex.Match(content, @"secret_key\s*=\s*""([^""]+)""");
+                Match match = LegacyTomlSecretRegex.Match(content);
                 secretKey = match.Success ? match.Groups[1].Value : null;
             }
             catch (Exception ex)
@@ -382,7 +387,7 @@ namespace PocketMC.Desktop.Features.Tunnel
                 Directory.CreateDirectory(directory);
             }
 
-            File.WriteAllText(tomlPath, $"secret_key = \"{secretKey}\"{Environment.NewLine}");
+            FileUtils.AtomicWriteAllText(tomlPath, $"secret_key = \"{secretKey}\"{Environment.NewLine}");
         }
 
         private void DeleteRuntimeToml()

--- a/PocketMC.Desktop/Infrastructure/JobObject.cs
+++ b/PocketMC.Desktop/Infrastructure/JobObject.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 namespace PocketMC.Desktop.Infrastructure
@@ -9,40 +10,49 @@ namespace PocketMC.Desktop.Infrastructure
     /// </summary>
     public sealed class JobObject : IDisposable
     {
-        private IntPtr _handle;
+        private readonly SafeJobHandle _handle;
         private bool _disposed;
 
         public JobObject()
         {
             _handle = CreateJobObject(IntPtr.Zero, null);
-            if (_handle == IntPtr.Zero)
+            if (_handle.IsInvalid)
                 throw new InvalidOperationException("Failed to create Windows Job Object.");
 
-            var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
-            {
-                BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
-                {
-                    LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-                }
-            };
-
-            int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
-            IntPtr ptr = Marshal.AllocHGlobal(length);
             try
             {
-                Marshal.StructureToPtr(extendedInfo, ptr, false);
-                if (!SetInformationJobObject(_handle, JobObjectInfoType.ExtendedLimitInformation, ptr, (uint)length))
-                    throw new InvalidOperationException("Failed to configure Job Object limits.");
+                var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+                {
+                    BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+                    {
+                        LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                    }
+                };
+
+                int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+                IntPtr ptr = Marshal.AllocHGlobal(length);
+                try
+                {
+                    Marshal.StructureToPtr(extendedInfo, ptr, false);
+                    if (!SetInformationJobObject(_handle, JobObjectInfoType.ExtendedLimitInformation, ptr, (uint)length))
+                        throw new InvalidOperationException("Failed to configure Job Object limits.");
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
             }
-            finally
+            catch
             {
-                Marshal.FreeHGlobal(ptr);
+                _handle.Dispose();
+                throw;
             }
         }
 
         public void AddProcess(IntPtr processHandle)
         {
             if (_disposed) throw new ObjectDisposedException(nameof(JobObject));
+            if (_handle.IsInvalid) throw new ObjectDisposedException(nameof(JobObject));
             if (!AssignProcessToJobObject(_handle, processHandle))
                 throw new InvalidOperationException("Failed to assign process to Job Object.");
         }
@@ -52,28 +62,39 @@ namespace PocketMC.Desktop.Infrastructure
             if (!_disposed)
             {
                 _disposed = true;
-                if (_handle != IntPtr.Zero)
-                {
-                    CloseHandle(_handle);
-                    _handle = IntPtr.Zero;
-                }
+                _handle.Dispose();
             }
+
+            GC.SuppressFinalize(this);
         }
 
         private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string? lpName);
+        private static extern SafeJobHandle CreateJobObject(IntPtr lpJobAttributes, string? lpName);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoType infoType, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+        private static extern bool SetInformationJobObject(SafeJobHandle hJob, JobObjectInfoType infoType, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+        private static extern bool AssignProcessToJobObject(SafeJobHandle hJob, IntPtr hProcess);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool CloseHandle(IntPtr hObject);
+
+        private sealed class SafeJobHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            private SafeJobHandle()
+                : base(ownsHandle: true)
+            {
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return CloseHandle(handle);
+            }
+        }
 
         private enum JobObjectInfoType
         {

--- a/PocketMC.Desktop/Infrastructure/Process/RconClient.cs
+++ b/PocketMC.Desktop/Infrastructure/Process/RconClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +10,9 @@ namespace PocketMC.Desktop.Infrastructure.Process;
 
 public class RconClient : IDisposable
 {
+    private const int MaxPacketLengthBytes = 1024 * 1024;
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(5);
+
     private readonly string _host;
     private readonly int _port;
     private readonly string _password;
@@ -25,12 +29,13 @@ public class RconClient : IDisposable
 
     public async Task ConnectAsync(CancellationToken ct = default)
     {
+        using var timeoutCts = CreateTimeoutTokenSource(ct);
         _client = new TcpClient();
-        await _client.ConnectAsync(_host, _port, ct);
+        await _client.ConnectAsync(_host, _port, timeoutCts.Token);
         _stream = _client.GetStream();
 
         // Authenticate
-        var result = await SendPacketAsync(3, _password, ct);
+        var result = await SendPacketAsync(3, _password, timeoutCts.Token);
         if (result.Id == -1)
         {
             throw new UnauthorizedAccessException("RCON authentication failed.");
@@ -41,7 +46,8 @@ public class RconClient : IDisposable
     public async Task<string> ExecuteCommandAsync(string command, CancellationToken ct = default)
     {
         if (!_authenticated) throw new InvalidOperationException("Not authenticated.");
-        var result = await SendPacketAsync(2, command, ct);
+        using var timeoutCts = CreateTimeoutTokenSource(ct);
+        var result = await SendPacketAsync(2, command, timeoutCts.Token);
         return result.Body;
     }
 
@@ -49,24 +55,36 @@ public class RconClient : IDisposable
     {
         if (_stream == null) throw new InvalidOperationException("Not connected.");
 
-        int id = new Random().Next();
+        int id = RandomNumberGenerator.GetInt32(1, int.MaxValue);
         byte[] bodyBytes = Encoding.UTF8.GetBytes(body);
         int length = 4 + 4 + bodyBytes.Length + 2;
 
         byte[] packet = new byte[length + 4];
-        BitConverter.GetBytes(length).CopyTo(packet, 0);
-        BitConverter.GetBytes(id).CopyTo(packet, 4);
-        BitConverter.GetBytes(type).CopyTo(packet, 8);
-        bodyBytes.CopyTo(packet, 12);
-        packet[packet.Length - 2] = 0;
-        packet[packet.Length - 1] = 0;
+        try
+        {
+            BitConverter.GetBytes(length).CopyTo(packet, 0);
+            BitConverter.GetBytes(id).CopyTo(packet, 4);
+            BitConverter.GetBytes(type).CopyTo(packet, 8);
+            bodyBytes.CopyTo(packet, 12);
+            packet[packet.Length - 2] = 0;
+            packet[packet.Length - 1] = 0;
 
-        await _stream.WriteAsync(packet, 0, packet.Length, ct);
+            await _stream.WriteAsync(packet, 0, packet.Length, ct);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(bodyBytes);
+            CryptographicOperations.ZeroMemory(packet);
+        }
 
         // Read response
         byte[] lenBuf = new byte[4];
         await ReadExactAsync(lenBuf, 4, ct);
         int respLen = BitConverter.ToInt32(lenBuf, 0);
+        if (respLen < 10 || respLen > MaxPacketLengthBytes)
+        {
+            throw new InvalidDataException($"Invalid RCON response length: {respLen} bytes.");
+        }
 
         byte[] respData = new byte[respLen];
         await ReadExactAsync(respData, respLen, ct);
@@ -83,10 +101,17 @@ public class RconClient : IDisposable
         int totalRead = 0;
         while (totalRead < count)
         {
-            int read = await _stream!.ReadAsync(buffer, totalRead, count - totalRead, ct);
+            int read = await _stream!.ReadAsync(buffer.AsMemory(totalRead, count - totalRead), ct);
             if (read == 0) throw new IOException("End of stream reached.");
             totalRead += read;
         }
+    }
+
+    private static CancellationTokenSource CreateTimeoutTokenSource(CancellationToken ct)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(OperationTimeout);
+        return cts;
     }
 
     public void Dispose()

--- a/PocketMC.Desktop/Infrastructure/Security/DataProtector.cs
+++ b/PocketMC.Desktop/Infrastructure/Security/DataProtector.cs
@@ -57,6 +57,11 @@ namespace PocketMC.Desktop.Infrastructure.Security
                 plainBytes = ProtectedData.Unprotect(cipherBytes, Entropy, Scope);
                 return Encoding.UTF8.GetString(plainBytes);
             }
+            catch (CryptographicException) when (!hasPrefix)
+            {
+                // Legacy plaintext settings can be Base64-shaped. Only versioned payloads fail closed.
+                return cipherText;
+            }
             catch (CryptographicException)
             {
                 throw;

--- a/PocketMC.Desktop/Infrastructure/Security/DataProtector.cs
+++ b/PocketMC.Desktop/Infrastructure/Security/DataProtector.cs
@@ -6,32 +6,65 @@ namespace PocketMC.Desktop.Infrastructure.Security
 {
     public static class DataProtector
     {
+        private const string ProtectedPrefix = "dpapi:v1:";
         private const DataProtectionScope Scope = DataProtectionScope.CurrentUser;
         private static readonly byte[] Entropy = Encoding.UTF8.GetBytes("PocketMC-LocalSettings");
 
         public static string Protect(string plainText)
         {
             if (string.IsNullOrEmpty(plainText)) return plainText;
-            byte[] plainBytes = Encoding.UTF8.GetBytes(plainText);
-            byte[] cipherBytes = ProtectedData.Protect(plainBytes, Entropy, Scope);
-            return Convert.ToBase64String(cipherBytes);
+
+            byte[]? plainBytes = null;
+            byte[]? cipherBytes = null;
+            try
+            {
+                plainBytes = Encoding.UTF8.GetBytes(plainText);
+                cipherBytes = ProtectedData.Protect(plainBytes, Entropy, Scope);
+                return ProtectedPrefix + Convert.ToBase64String(cipherBytes);
+            }
+            finally
+            {
+                if (plainBytes != null) CryptographicOperations.ZeroMemory(plainBytes);
+                if (cipherBytes != null) CryptographicOperations.ZeroMemory(cipherBytes);
+            }
         }
 
         public static string Unprotect(string cipherText)
         {
             if (string.IsNullOrEmpty(cipherText)) return cipherText;
+
+            bool hasPrefix = cipherText.StartsWith(ProtectedPrefix, StringComparison.Ordinal);
+            string payload = hasPrefix ? cipherText[ProtectedPrefix.Length..] : cipherText;
+            byte[]? cipherBytes = null;
+            byte[]? plainBytes = null;
+
             try
             {
-                byte[] cipherBytes = Convert.FromBase64String(cipherText);
-                byte[] plainBytes = ProtectedData.Unprotect(cipherBytes, Entropy, Scope);
+                cipherBytes = Convert.FromBase64String(payload);
+            }
+            catch (FormatException) when (!hasPrefix)
+            {
+                // Legacy plaintext fallback: non-Base64 settings predate DPAPI protection.
+                return cipherText;
+            }
+            catch (FormatException ex)
+            {
+                throw new CryptographicException("Protected setting payload is not valid Base64.", ex);
+            }
+
+            try
+            {
+                plainBytes = ProtectedData.Unprotect(cipherBytes, Entropy, Scope);
                 return Encoding.UTF8.GetString(plainBytes);
             }
-            catch
+            catch (CryptographicException)
             {
-                // Legacy plaintext fallback: if it cannot be decoded as Base64 or decrypted via DPAPI,
-                // assume it was saved in plaintext prior to this security feature.
-                // It will be re-encrypted automatically on next save.
-                return cipherText;
+                throw;
+            }
+            finally
+            {
+                if (cipherBytes != null) CryptographicOperations.ZeroMemory(cipherBytes);
+                if (plainBytes != null) CryptographicOperations.ZeroMemory(plainBytes);
             }
         }
     }

--- a/PocketMC.Desktop/Infrastructure/Security/PathSafety.cs
+++ b/PocketMC.Desktop/Infrastructure/Security/PathSafety.cs
@@ -11,8 +11,8 @@ namespace PocketMC.Desktop.Infrastructure.Security
     {
         private static readonly char[] DirectorySeparators =
         [
-            Path.DirectorySeparatorChar,
-            Path.AltDirectorySeparatorChar
+            '\\',
+            '/'
         ];
 
         /// <summary>
@@ -22,7 +22,6 @@ namespace PocketMC.Desktop.Infrastructure.Security
         /// </summary>
         public static bool ContainsTraversal(string relativePath)
         {
-            const string syntheticRoot = @"C:\syntheticroot\";
             if (IsUnsafeRelativePath(relativePath))
             {
                 return true;
@@ -30,8 +29,8 @@ namespace PocketMC.Desktop.Infrastructure.Security
 
             try
             {
-                string resolved = Path.GetFullPath(Path.Combine(syntheticRoot, relativePath));
-                return !resolved.StartsWith(syntheticRoot, StringComparison.OrdinalIgnoreCase);
+                _ = Path.GetFullPath(relativePath);
+                return false;
             }
             catch
             {
@@ -50,12 +49,10 @@ namespace PocketMC.Desktop.Infrastructure.Security
                 return null;
             }
 
-            string root = Path.GetFullPath(rootDirectory);
-            if (!root.EndsWith(Path.DirectorySeparatorChar))
-                root += Path.DirectorySeparatorChar;
+            string root = EnsureTrailingDirectorySeparator(Path.GetFullPath(rootDirectory));
 
             string resolved = Path.GetFullPath(Path.Combine(rootDirectory, relativePath));
-            return resolved.StartsWith(root, StringComparison.OrdinalIgnoreCase) ? resolved : null;
+            return resolved.StartsWith(root, GetPathComparison()) ? resolved : null;
         }
 
         private static bool IsUnsafeRelativePath(string relativePath)
@@ -65,7 +62,7 @@ namespace PocketMC.Desktop.Infrastructure.Security
                 return true;
             }
 
-            if (Path.IsPathRooted(relativePath))
+            if (Path.IsPathRooted(relativePath) || IsWindowsRootedPath(relativePath))
             {
                 return true;
             }
@@ -84,6 +81,39 @@ namespace PocketMC.Desktop.Infrastructure.Security
             }
 
             return false;
+        }
+
+        private static bool IsWindowsRootedPath(string path)
+        {
+            if (path.StartsWith(@"\\", StringComparison.Ordinal) ||
+                path.StartsWith("//", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return path.Length >= 3 &&
+                   IsAsciiLetter(path[0]) &&
+                   path[1] == ':' &&
+                   (path[2] == '\\' || path[2] == '/');
+        }
+
+        private static bool IsAsciiLetter(char value)
+        {
+            return (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z');
+        }
+
+        private static string EnsureTrailingDirectorySeparator(string path)
+        {
+            return path.EndsWith('\\') || path.EndsWith('/')
+                ? path
+                : path + Path.DirectorySeparatorChar;
+        }
+
+        private static StringComparison GetPathComparison()
+        {
+            return OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
         }
     }
 }

--- a/PocketMC.Desktop/Infrastructure/Security/PathSafety.cs
+++ b/PocketMC.Desktop/Infrastructure/Security/PathSafety.cs
@@ -9,6 +9,12 @@ namespace PocketMC.Desktop.Infrastructure.Security
     /// </summary>
     public static class PathSafety
     {
+        private static readonly char[] DirectorySeparators =
+        [
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar
+        ];
+
         /// <summary>
         /// Checks if a relative file path contains traversal sequences (../, ..\)
         /// that could escape a root directory. Safe to call during parse-time
@@ -17,6 +23,11 @@ namespace PocketMC.Desktop.Infrastructure.Security
         public static bool ContainsTraversal(string relativePath)
         {
             const string syntheticRoot = @"C:\syntheticroot\";
+            if (IsUnsafeRelativePath(relativePath))
+            {
+                return true;
+            }
+
             try
             {
                 string resolved = Path.GetFullPath(Path.Combine(syntheticRoot, relativePath));
@@ -34,12 +45,45 @@ namespace PocketMC.Desktop.Infrastructure.Security
         /// </summary>
         public static string? ValidateContainedPath(string rootDirectory, string relativePath)
         {
+            if (IsUnsafeRelativePath(relativePath))
+            {
+                return null;
+            }
+
             string root = Path.GetFullPath(rootDirectory);
             if (!root.EndsWith(Path.DirectorySeparatorChar))
                 root += Path.DirectorySeparatorChar;
 
             string resolved = Path.GetFullPath(Path.Combine(rootDirectory, relativePath));
             return resolved.StartsWith(root, StringComparison.OrdinalIgnoreCase) ? resolved : null;
+        }
+
+        private static bool IsUnsafeRelativePath(string relativePath)
+        {
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                return true;
+            }
+
+            if (Path.IsPathRooted(relativePath))
+            {
+                return true;
+            }
+
+            foreach (string segment in relativePath.Split(DirectorySeparators, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (segment == "." || segment == "..")
+                {
+                    return true;
+                }
+
+                if (segment.Contains(':', StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/PocketMC.Desktop/Infrastructure/UwpLoopbackHelper.cs
+++ b/PocketMC.Desktop/Infrastructure/UwpLoopbackHelper.cs
@@ -103,8 +103,8 @@ public static class UwpLoopbackHelper
 
         try
         {
-            await proc.WaitForExitAsync(cts.Token);
-            await Task.WhenAll(outputTask, errorTask);
+            await proc.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+            await Task.WhenAll(outputTask, errorTask).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/PocketMC.Desktop/Infrastructure/UwpLoopbackHelper.cs
+++ b/PocketMC.Desktop/Infrastructure/UwpLoopbackHelper.cs
@@ -1,6 +1,9 @@
 using System;
 using System.ComponentModel;
+using System.Threading;
 using System.Threading.Tasks;
+using DiagnosticsProcess = System.Diagnostics.Process;
+using DiagnosticsProcessStartInfo = System.Diagnostics.ProcessStartInfo;
 
 namespace PocketMC.Desktop.Infrastructure;
 
@@ -13,6 +16,8 @@ namespace PocketMC.Desktop.Infrastructure;
 /// </summary>
 public static class UwpLoopbackHelper
 {
+    private static readonly TimeSpan CheckNetIsolationTimeout = TimeSpan.FromSeconds(5);
+
     /// <summary>
     /// The Windows Store package family name for Minecraft Bedrock Edition (UWP).
     /// </summary>
@@ -26,22 +31,7 @@ public static class UwpLoopbackHelper
     {
         try
         {
-            var psi = new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = "CheckNetIsolation.exe",
-                Arguments = "LoopbackExempt -s",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                CreateNoWindow = true
-            };
-
-            using var proc = System.Diagnostics.Process.Start(psi);
-            if (proc == null) return false;
-
-            string output = proc.StandardOutput.ReadToEnd();
-            proc.WaitForExit();
-
-            return output.Contains(MinecraftPackageFamilyName, StringComparison.OrdinalIgnoreCase);
+            return IsExemptionPresentAsync().GetAwaiter().GetResult();
         }
         catch
         {
@@ -66,7 +56,7 @@ public static class UwpLoopbackHelper
         {
             // "runas" forces the UAC elevation dialog so CheckNetIsolation can
             // write to the protected loopback-exemption registry hive.
-            var psi = new System.Diagnostics.ProcessStartInfo
+            var psi = new DiagnosticsProcessStartInfo
             {
                 FileName = "CheckNetIsolation.exe",
                 Arguments = $"LoopbackExempt -a -n=\"{MinecraftPackageFamilyName}\"",
@@ -75,7 +65,7 @@ public static class UwpLoopbackHelper
                 CreateNoWindow = false   // shell must be visible for UAC dialog
             };
 
-            using var proc = System.Diagnostics.Process.Start(psi);
+            using var proc = DiagnosticsProcess.Start(psi);
             if (proc == null) return false;
 
             await proc.WaitForExitAsync();
@@ -89,6 +79,55 @@ public static class UwpLoopbackHelper
         catch
         {
             return false;
+        }
+    }
+
+    private static async Task<bool> IsExemptionPresentAsync()
+    {
+        var psi = new DiagnosticsProcessStartInfo
+        {
+            FileName = "CheckNetIsolation.exe",
+            Arguments = "LoopbackExempt -s",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var proc = DiagnosticsProcess.Start(psi);
+        if (proc == null) return false;
+
+        using var cts = new CancellationTokenSource(CheckNetIsolationTimeout);
+        Task<string> outputTask = proc.StandardOutput.ReadToEndAsync(cts.Token);
+        Task<string> errorTask = proc.StandardError.ReadToEndAsync(cts.Token);
+
+        try
+        {
+            await proc.WaitForExitAsync(cts.Token);
+            await Task.WhenAll(outputTask, errorTask);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKillProcessTree(proc);
+            return false;
+        }
+
+        return proc.ExitCode == 0 &&
+               outputTask.Result.Contains(MinecraftPackageFamilyName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void TryKillProcessTree(DiagnosticsProcess proc)
+    {
+        try
+        {
+            if (!proc.HasExited)
+            {
+                proc.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // Best-effort timeout cleanup; callers already receive false.
         }
     }
 }


### PR DESCRIPTION
## Summary
- Tightened settings secret handling so cloud OAuth tokens are encrypted before serialization and DPAPI decryption fails closed on corrupted payloads.
- Hardened archive and add-on extraction paths against rooted paths, colon-based ADS paths, empty sanitized pack names, and non-atomic world JSON writes.
- Fixed process orchestration risks by draining redirected Java output concurrently, bounding RCON packet sizes, and adding request timeouts.
- Added OAuth `state` validation for loopback callbacks and regression tests covering the security fixes.

## Testing
- `dotnet test PocketMC.Desktop.sln`  pass: 258 passed, 0 failed, 0 skipped.