### PR TITLE
Phase 1 hardening: safety fixes for downloads, locks, backups, settings, and Drive queries

### DIFF
--- a/PocketMC.Desktop/Features/CloudBackups/Providers/GoogleDriveBackupProvider.cs
+++ b/PocketMC.Desktop/Features/CloudBackups/Providers/GoogleDriveBackupProvider.cs
@@ -228,11 +228,23 @@ public class GoogleDriveBackupProvider : ICloudBackupProvider
         }
     }
 
+    private static string EscapeDriveQueryStringLiteral(string value)
+    {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+        return value.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("'", "\\'", StringComparison.Ordinal);
+    }
+
+    private static string FolderNameEqualsQuery(string folderName)
+    {
+        return $"mimeType='application/vnd.google-apps.folder' and name='{EscapeDriveQueryStringLiteral(folderName)}' and trashed=false";
+    }
+
     private async Task<string> GetOrCreateFolderAsync(DriveService service, string folderName, string? parentId = null)
     {
         var request = service.Files.List();
-        request.Q = $"mimeType='application/vnd.google-apps.folder' and name='{folderName}' and trashed=false";
-        if (parentId != null) request.Q += $" and '{parentId}' in parents";
+        request.Q = FolderNameEqualsQuery(folderName);
+        if (parentId != null) request.Q += $" and '{EscapeDriveQueryStringLiteral(parentId)}' in parents";
         else request.Q += " and 'root' in parents";
 
         var result = await request.ExecuteAsync();
@@ -324,7 +336,7 @@ public class GoogleDriveBackupProvider : ICloudBackupProvider
         string instanceFolderName = $"{CloudPathSanitizer.SanitizeFolderName(instanceName)}-{instanceId}";
         
         var folderReq = service.Files.List();
-        folderReq.Q = $"mimeType='application/vnd.google-apps.folder' and name='{instanceFolderName}' and trashed=false";
+        folderReq.Q = FolderNameEqualsQuery(instanceFolderName);
         var folderRes = await folderReq.ExecuteAsync(ct);
         
         if (folderRes.Files == null || folderRes.Files.Count == 0) return Array.Empty<CloudRemoteBackupItem>();
@@ -332,7 +344,7 @@ public class GoogleDriveBackupProvider : ICloudBackupProvider
         string folderId = folderRes.Files[0].Id;
 
         var listReq = service.Files.List();
-        listReq.Q = $"'{folderId}' in parents and trashed=false";
+        listReq.Q = $"'{EscapeDriveQueryStringLiteral(folderId)}' in parents and trashed=false";
         listReq.Fields = "files(id, name, size, createdTime)";
         
         var listRes = await listReq.ExecuteAsync(ct);

--- a/PocketMC.Desktop/Features/Instances/Backups/BackupService.cs
+++ b/PocketMC.Desktop/Features/Instances/Backups/BackupService.cs
@@ -240,27 +240,21 @@ public class BackupService
 
     private async Task<LocalBackupResult> CreateLocalBackupAsync(InstanceMetadata metadata, string serverDir, Action<string>? onProgress)
     {
-        string worldFolderName = "world";
-        if (metadata.ServerType?.StartsWith("Pocketmine", StringComparison.OrdinalIgnoreCase) == true)
+        string worldDir;
+        string worldDisplayName;
+        try
         {
-            worldFolderName = "worlds";
+            worldDir = ResolveWorldDirectory(metadata, serverDir);
+            worldDisplayName = Path.GetRelativePath(serverDir, worldDir);
         }
-        else if (metadata.ServerType?.StartsWith("Bedrock", StringComparison.OrdinalIgnoreCase) == true)
+        catch (Exception ex)
         {
-            if (_configService.TryGetProperty(serverDir, "level-name", out var levelName) && !string.IsNullOrWhiteSpace(levelName))
-            {
-                worldFolderName = Path.Combine("worlds", levelName.Trim());
-            }
-            else
-            {
-                worldFolderName = Path.Combine("worlds", "Bedrock level");
-            }
+            return new LocalBackupResult { Success = false, Error = ex };
         }
 
-        var worldDir = Path.Combine(serverDir, worldFolderName);
         if (!Directory.Exists(worldDir))
         {
-            return new LocalBackupResult { Success = false, Error = new DirectoryNotFoundException($"World folder '{worldFolderName}' not found in server directory.") };
+            return new LocalBackupResult { Success = false, Error = new DirectoryNotFoundException($"World folder '{worldDisplayName}' not found in server directory.") };
         }
 
         var backupDir = GetBackupDirectory(serverDir, metadata);
@@ -356,6 +350,55 @@ public class BackupService
         }
     }
 
+    private string ResolveWorldDirectory(InstanceMetadata metadata, string serverDir)
+    {
+        if (metadata.ServerType?.StartsWith("Pocketmine", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return Path.Combine(serverDir, "worlds");
+        }
+
+        if (metadata.ServerType?.StartsWith("Bedrock", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            string levelName = "Bedrock level";
+            if (_configService.TryGetProperty(serverDir, "level-name", out var configuredLevelName) &&
+                !string.IsNullOrWhiteSpace(configuredLevelName))
+            {
+                levelName = configuredLevelName.Trim();
+            }
+
+            string safeLevelName = ValidateBedrockLevelName(levelName);
+            string worldsRoot = Path.Combine(serverDir, "worlds");
+            string? resolved = PathSafety.ValidateContainedPath(worldsRoot, safeLevelName);
+            if (resolved == null)
+            {
+                throw new InvalidDataException("Bedrock level-name resolves outside the worlds directory. Refusing backup/restore for safety.");
+            }
+
+            return resolved;
+        }
+
+        return Path.Combine(serverDir, "world");
+    }
+
+    internal static string ValidateBedrockLevelName(string levelName)
+    {
+        string trimmed = levelName.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            throw new InvalidDataException("Bedrock level-name cannot be empty.");
+        }
+
+        if (trimmed.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+            trimmed.IndexOfAny(new[] { '/', '\\', ':', '\0', '\r', '\n', '\t' }) >= 0 ||
+            PathSafety.ContainsTraversal(trimmed) ||
+            Path.IsPathRooted(trimmed))
+        {
+            throw new InvalidDataException($"Bedrock level-name '{trimmed}' is not safe to use as a world folder name.");
+        }
+
+        return trimmed;
+    }
+
     private async Task ReplicateToExternalDirectoryAsync(InstanceMetadata metadata, string zipPath, Action<string>? onProgress)
     {
         var appSettings = _settingsManager.Load();
@@ -446,24 +489,7 @@ public class BackupService
 
     public async Task RestoreBackupAsync(InstanceMetadata metadata, string backupZipPath, string serverDir, Action<string>? onProgress = null)
     {
-        string worldFolderName = "world";
-        if (metadata.ServerType?.StartsWith("Pocketmine", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            worldFolderName = "worlds";
-        }
-        else if (metadata.ServerType?.StartsWith("Bedrock", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            if (_configService.TryGetProperty(serverDir, "level-name", out var levelName) && !string.IsNullOrWhiteSpace(levelName))
-            {
-                worldFolderName = Path.Combine("worlds", levelName.Trim());
-            }
-            else
-            {
-                worldFolderName = Path.Combine("worlds", "Bedrock level");
-            }
-        }
-
-        var worldDir = Path.Combine(serverDir, worldFolderName);
+        string worldDir = ResolveWorldDirectory(metadata, serverDir);
 
         if (string.IsNullOrWhiteSpace(backupZipPath) || !File.Exists(backupZipPath))
         {

--- a/PocketMC.Desktop/Features/Instances/Models/ServerProcess.cs
+++ b/PocketMC.Desktop/Features/Instances/Models/ServerProcess.cs
@@ -110,7 +110,7 @@ public class ServerProcess : IDisposable
         WorkingDirectory = workingDir;
         CloseSessionLog();
         InitializeSessionLog(workingDir);
-        CleanSessionLock(workingDir);
+        InspectSessionLock(workingDir);
 
         try
         {
@@ -152,20 +152,23 @@ public class ServerProcess : IDisposable
         catch (Exception ex) { _logger.LogWarning(ex, "Failed to initialize session log."); }
     }
 
-    private void CleanSessionLock(string workingDir)
+    private void InspectSessionLock(string workingDir)
     {
         try
         {
             string lockPath = Path.Combine(workingDir, "world", "session.lock");
-            if (File.Exists(lockPath))
+            if (!File.Exists(lockPath))
             {
-                _logger.LogInformation("Found stale session.lock for instance {InstanceId}. Cleaning up...", InstanceId);
-                File.Delete(lockPath);
+                return;
             }
+
+            string warning = "[PocketMC] Warning: world/session.lock already exists. PocketMC will not delete it automatically because that can hide an active world lock and risk corruption. If startup fails, stop any other server using this world or remove the stale lock manually only after verifying the world is not in use.";
+            _logger.LogWarning("Detected existing Minecraft session.lock for instance {InstanceId} at {LockPath}. PocketMC will not delete it automatically.", InstanceId, lockPath);
+            AppendOutput(warning);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to clean session.lock for instance {InstanceId}. Launch might fail.", InstanceId);
+            _logger.LogWarning(ex, "Failed to inspect session.lock for instance {InstanceId}. Launch will continue without deleting lock files.", InstanceId);
         }
     }
 
@@ -277,7 +280,18 @@ public class ServerProcess : IDisposable
                 }
             }
         }
-        catch { }
+        catch (ObjectDisposedException)
+        {
+            _logger.LogDebug("Server process stream closed for instance {InstanceId}.", InstanceId);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogDebug(ex, "Server process stream ended for instance {InstanceId}.", InstanceId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Server process stream reader failed for instance {InstanceId}. IsErrorStream={IsErrorStream}", InstanceId, isError);
+        }
     }
 
     private void AppendOutput(string line, bool isError = false)

--- a/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
@@ -15,10 +15,7 @@ namespace PocketMC.Desktop.Features.Instances.Services;
         private const string DownloadClientName = "PocketMC.Downloads";
         private const string PlayitAgentVersion = "0.17.1";
         private const string PlayitDownloadUrl = "https://github.com/playit-cloud/playit-agent/releases/download/v0.17.1/playit-windows-x86_64-signed.exe";
-
-        // Playit does not currently expose a stable checksum in the app's source of truth.
-        // Keep this nullable until a verified upstream SHA256 is recorded, then fail closed on mismatch.
-        private const string? PlayitExpectedSha256 = null;
+        private const string? PlayitExpectedSha256 = "9b00d6ff7d37d1052e5ae097e1348e11deae8617cd7a8ba39d1777f2006316a3";
 
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<DownloaderService> _logger;

--- a/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using PocketMC.Desktop.Features.Instances.Models;
 using System.IO;
 using System.Net.Http;
@@ -11,6 +13,13 @@ namespace PocketMC.Desktop.Features.Instances.Services;
     public class DownloaderService
     {
         private const string DownloadClientName = "PocketMC.Downloads";
+        private const string PlayitAgentVersion = "0.17.1";
+        private const string PlayitDownloadUrl = "https://github.com/playit-cloud/playit-agent/releases/download/v0.17.1/playit-windows-x86_64-signed.exe";
+
+        // Playit does not currently expose a stable checksum in the app's source of truth.
+        // Keep this nullable until a verified upstream SHA256 is recorded, then fail closed on mismatch.
+        private const string? PlayitExpectedSha256 = null;
+
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<DownloaderService> _logger;
 
@@ -89,7 +98,6 @@ namespace PocketMC.Desktop.Features.Instances.Services;
                         await DownloadToPartialAsync(response, partialPath, existingBytes, progress, cancellationToken);
                     }
 
-                    // Verification
                     if (!string.IsNullOrEmpty(expectedHash))
                     {
                         string hashType = NormalizeHashType(expectedHash, expectedHashType);
@@ -156,27 +164,90 @@ namespace PocketMC.Desktop.Features.Instances.Services;
         }
 
         /// <summary>
-        /// Downloads playit.exe into <appRoot>/tunnel/playit.exe if not already present.
+        /// Downloads playit.exe into &lt;appRoot&gt;/tunnel/playit.exe if not already present.
+        /// The executable is staged first and must pass configured verification before promotion.
         /// </summary>
         public async Task EnsurePlayitDownloadedAsync(string appRootPath, IProgress<DownloadProgress>? progress = null, CancellationToken cancellationToken = default)
         {
-            // Note: For 'latest' URL, the hash isn't stable. 
-            // Ideally, we should fetch the hash from a sidecar file or pin the version.
-            // For now, we allow the download but provide the hook for verification.
-            const string playitDownloadUrl = "https://github.com/playit-cloud/playit-agent/releases/download/v0.17.1/playit-windows-x86_64-signed.exe";
-
             string tunnelDir = Path.Combine(appRootPath, "tunnel");
             string playitPath = Path.Combine(tunnelDir, "playit.exe");
 
             if (File.Exists(playitPath))
             {
-                return;
+                if (await ValidatePlayitExecutableAsync(playitPath, cancellationToken))
+                {
+                    return;
+                }
+
+                _logger.LogWarning("Existing Playit agent at {PlayitPath} failed validation and will be replaced.", playitPath);
+                TryDeleteFile(playitPath);
             }
 
             Directory.CreateDirectory(tunnelDir);
-            await DownloadFileAsync(playitDownloadUrl, playitPath, null, progress, cancellationToken);
+
+            string stagedPath = Path.Combine(tunnelDir, $"playit-{PlayitAgentVersion}-{Guid.NewGuid():N}.exe");
+            try
+            {
+                await DownloadFileAsync(
+                    PlayitDownloadUrl,
+                    stagedPath,
+                    PlayitExpectedSha256,
+                    PlayitExpectedSha256 == null ? null : "SHA256",
+                    progress,
+                    cancellationToken);
+
+                if (!await ValidatePlayitExecutableAsync(stagedPath, cancellationToken))
+                {
+                    throw new CryptographicException("Downloaded Playit agent failed executable signature validation.");
+                }
+
+                await PromoteCompletedDownloadAsync(stagedPath, playitPath, cancellationToken);
+            }
+            catch
+            {
+                TryDeleteFile(stagedPath);
+                TryDeleteFile(stagedPath + ".partial");
+                throw;
+            }
         }
-// ... rest of file (ExtractZipAsync, etc.)
+
+        private async Task<bool> ValidatePlayitExecutableAsync(string filePath, CancellationToken cancellationToken)
+        {
+            if (!File.Exists(filePath))
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(PlayitExpectedSha256))
+            {
+                return await VerifyHashAsync(filePath, PlayitExpectedSha256, "SHA256", cancellationToken);
+            }
+
+            try
+            {
+                using X509Certificate certificate = X509Certificate.CreateFromSignedFile(filePath);
+                string subject = certificate.Subject ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(subject))
+                {
+                    _logger.LogWarning("Playit agent signature exists but has an empty certificate subject: {FilePath}", filePath);
+                    return false;
+                }
+
+                FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(filePath);
+                _logger.LogInformation(
+                    "Validated signed Playit agent {FilePath}. Publisher={Publisher}, Product={ProductName}, FileVersion={FileVersion}",
+                    filePath,
+                    subject,
+                    versionInfo.ProductName,
+                    versionInfo.FileVersion);
+                return true;
+            }
+            catch (Exception ex) when (ex is CryptographicException or FileNotFoundException or ArgumentException)
+            {
+                _logger.LogError(ex, "Playit agent executable failed signed-file validation: {FilePath}", filePath);
+                return false;
+            }
+        }
 
         public Task ExtractZipAsync(string zipPath, string extractPath, IProgress<DownloadProgress>? progress = null)
         {
@@ -314,4 +385,3 @@ namespace PocketMC.Desktop.Features.Instances.Services;
             }
         }
     }
-

--- a/PocketMC.Desktop/Features/Instances/Services/ServerProcessManager.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/ServerProcessManager.cs
@@ -61,9 +61,6 @@ public class ServerProcessManager
 
     public async Task<ServerProcess> StartProcessAsync(InstanceMetadata meta, string appRootPath)
     {
-        if (_activeProcesses.ContainsKey(meta.Id))
-            throw new InvalidOperationException($"Server '{meta.Name}' is already running.");
-
         var instancePath = _registry.GetPath(meta.Id)
             ?? throw new DirectoryNotFoundException($"Could not locate directory for instance {meta.Name}.");
 
@@ -75,6 +72,14 @@ public class ServerProcessManager
             _consoleLogHistoryService,
             _loggerFactory.CreateLogger<ServerProcess>());
 
+        if (!_activeProcesses.TryAdd(meta.Id, serverProcess))
+        {
+            serverProcess.Dispose();
+            throw new InvalidOperationException($"Server '{meta.Name}' is already running or starting.");
+        }
+
+        _historicalProcesses[meta.Id] = serverProcess;
+
         serverProcess.OnStateChanged += state =>
         {
             OnInstanceStateChanged?.Invoke(meta.Id, state);
@@ -83,9 +88,6 @@ public class ServerProcessManager
         };
 
         serverProcess.OnServerCrashed += crashLog => OnServerCrashed?.Invoke(meta.Id, crashLog);
-
-        _activeProcesses[meta.Id] = serverProcess;
-        _historicalProcesses[meta.Id] = serverProcess;
 
         try
         {
@@ -96,6 +98,7 @@ public class ServerProcessManager
         catch
         {
             _activeProcesses.TryRemove(meta.Id, out _);
+            serverProcess.Dispose();
             throw;
         }
 

--- a/PocketMC.Desktop/Features/Settings/SettingsManager.cs
+++ b/PocketMC.Desktop/Features/Settings/SettingsManager.cs
@@ -11,8 +11,11 @@ namespace PocketMC.Desktop.Features.Settings
 {
     public class SettingsManager
     {
+        private static readonly JsonSerializerOptions SettingsJsonOptions = new() { WriteIndented = true };
+
         private readonly string _settingsFilePath;
         private readonly ILogger<SettingsManager>? _logger;
+        private readonly object _settingsLock = new();
 
         public SettingsManager(ILogger<SettingsManager>? logger = null)
         {
@@ -36,129 +39,57 @@ namespace PocketMC.Desktop.Features.Settings
 
         public AppSettings Load()
         {
-            if (!File.Exists(_settingsFilePath))
+            lock (_settingsLock)
             {
-                return CreateDefaultSettings();
-            }
+                if (!File.Exists(_settingsFilePath))
+                {
+                    return CreateDefaultSettings();
+                }
 
-            AppSettings? settings;
-            try
-            {
-                var content = File.ReadAllText(_settingsFilePath);
-                settings = JsonSerializer.Deserialize<AppSettings>(content);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to load settings from {SettingsFilePath}. Falling back to defaults.", _settingsFilePath);
-                return CreateDefaultSettings();
-            }
+                AppSettings? settings;
+                try
+                {
+                    var content = File.ReadAllText(_settingsFilePath);
+                    settings = JsonSerializer.Deserialize<AppSettings>(content);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Failed to load settings from {SettingsFilePath}. Falling back to defaults.", _settingsFilePath);
+                    return CreateDefaultSettings();
+                }
 
-            settings = Normalize(settings);
-            UnprotectSecrets(settings);
-            return settings;
+                settings = Normalize(settings);
+                UnprotectSecrets(settings);
+                return settings;
+            }
         }
 
         public void Save(AppSettings settings)
         {
-            var normalizedSettings = Normalize(settings);
-            var directory = Path.GetDirectoryName(_settingsFilePath);
-            if (!Directory.Exists(directory) && directory != null)
+            if (settings == null)
             {
-                Directory.CreateDirectory(directory);
+                throw new ArgumentNullException(nameof(settings));
             }
 
-            var originalCurseForgeKey = normalizedSettings.CurseForgeApiKey;
-            var originalPlayitSecret = normalizedSettings.PlayitPartnerConnection?.AgentSecretKey;
-            var originalAiApiKeys = new System.Collections.Generic.Dictionary<string, string>(normalizedSettings.AiApiKeys, StringComparer.OrdinalIgnoreCase);
-
-            var originalCloudTokens = new System.Collections.Generic.Dictionary<string, CloudOAuthTokenSet>(StringComparer.OrdinalIgnoreCase);
-            if (normalizedSettings.CloudTokens != null)
+            lock (_settingsLock)
             {
-                foreach (var kvp in normalizedSettings.CloudTokens)
+                var normalizedSettings = Normalize(CloneSettings(settings));
+                var directory = Path.GetDirectoryName(_settingsFilePath);
+                if (!Directory.Exists(directory) && directory != null)
                 {
-                    originalCloudTokens[kvp.Key] = new CloudOAuthTokenSet
-                    {
-                        Provider = kvp.Value.Provider,
-                        AccessToken = kvp.Value.AccessToken,
-                        RefreshToken = kvp.Value.RefreshToken,
-                        ExpiresAtUtc = kvp.Value.ExpiresAtUtc,
-                        Scope = kvp.Value.Scope,
-                        TokenType = kvp.Value.TokenType,
-                        AccountId = kvp.Value.AccountId
-                    };
-                }
-            }
-
-            try
-            {
-                if (!string.IsNullOrEmpty(normalizedSettings.CurseForgeApiKey))
-                {
-                    normalizedSettings.CurseForgeApiKey = DataProtector.Protect(normalizedSettings.CurseForgeApiKey);
+                    Directory.CreateDirectory(directory);
                 }
 
-                if (!string.IsNullOrEmpty(normalizedSettings.PlayitPartnerConnection?.AgentSecretKey))
-                {
-                    normalizedSettings.PlayitPartnerConnection.AgentSecretKey =
-                        DataProtector.Protect(normalizedSettings.PlayitPartnerConnection.AgentSecretKey);
-                }
+                ProtectSecrets(normalizedSettings);
 
-                foreach (var kvp in originalAiApiKeys)
-                {
-                    if (!string.IsNullOrEmpty(kvp.Value))
-                    {
-                        normalizedSettings.AiApiKeys[kvp.Key] = DataProtector.Protect(kvp.Value);
-                    }
-                }
-
-                if (normalizedSettings.CloudTokens != null)
-                {
-                    foreach (var kvp in normalizedSettings.CloudTokens)
-                    {
-                        var tokenSet = kvp.Value;
-                        if (tokenSet != null)
-                        {
-                            if (!string.IsNullOrEmpty(tokenSet.AccessToken))
-                            {
-                                tokenSet.AccessToken = DataProtector.Protect(tokenSet.AccessToken);
-                            }
-                            if (!string.IsNullOrEmpty(tokenSet.RefreshToken))
-                            {
-                                tokenSet.RefreshToken = DataProtector.Protect(tokenSet.RefreshToken);
-                            }
-                        }
-                    }
-                }
-
-                var content = JsonSerializer.Serialize(normalizedSettings, new JsonSerializerOptions { WriteIndented = true });
+                var content = JsonSerializer.Serialize(normalizedSettings, SettingsJsonOptions);
                 FileUtils.AtomicWriteAllText(_settingsFilePath, content);
-            }
-            finally
-            {
-                normalizedSettings.CurseForgeApiKey = originalCurseForgeKey;
-                if (normalizedSettings.PlayitPartnerConnection != null)
-                {
-                    normalizedSettings.PlayitPartnerConnection.AgentSecretKey = originalPlayitSecret;
-                }
-                
-                normalizedSettings.AiApiKeys.Clear();
-                foreach (var kvp in originalAiApiKeys)
-                {
-                    normalizedSettings.AiApiKeys[kvp.Key] = kvp.Value;
-                }
-                if (normalizedSettings.CloudTokens != null)
-                {
-                    normalizedSettings.CloudTokens.Clear();
-                    foreach (var kvp in originalCloudTokens)
-                    {
-                        normalizedSettings.CloudTokens[kvp.Key] = kvp.Value;
-                    }
-                }
             }
         }
 
         public string GetPlayitTomlPath(AppSettings? settings = null)
         {
-            var effectiveSettings = Normalize(settings ?? Load());
+            var effectiveSettings = Normalize(settings == null ? Load() : CloneSettings(settings));
             return Path.Combine(effectiveSettings.PlayitConfigDirectory!, "playit.toml");
         }
 
@@ -174,6 +105,12 @@ namespace PocketMC.Desktop.Features.Settings
         private AppSettings CreateDefaultSettings()
         {
             return Normalize(new AppSettings());
+        }
+
+        private static AppSettings CloneSettings(AppSettings settings)
+        {
+            string json = JsonSerializer.Serialize(settings, SettingsJsonOptions);
+            return JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
         }
 
         private AppSettings Normalize(AppSettings? settings)
@@ -204,6 +141,49 @@ namespace PocketMC.Desktop.Features.Settings
             }
 
             return settings;
+        }
+
+        private void ProtectSecrets(AppSettings settings)
+        {
+            if (!string.IsNullOrEmpty(settings.CurseForgeApiKey))
+            {
+                settings.CurseForgeApiKey = DataProtector.Protect(settings.CurseForgeApiKey);
+            }
+
+            if (!string.IsNullOrEmpty(settings.PlayitPartnerConnection?.AgentSecretKey))
+            {
+                settings.PlayitPartnerConnection.AgentSecretKey =
+                    DataProtector.Protect(settings.PlayitPartnerConnection.AgentSecretKey);
+            }
+
+            foreach (var key in new System.Collections.Generic.List<string>(settings.AiApiKeys.Keys))
+            {
+                string value = settings.AiApiKeys[key];
+                if (!string.IsNullOrEmpty(value))
+                {
+                    settings.AiApiKeys[key] = DataProtector.Protect(value);
+                }
+            }
+
+            foreach (var key in new System.Collections.Generic.List<string>(settings.CloudTokens.Keys))
+            {
+                var tokenSet = settings.CloudTokens[key];
+                if (tokenSet == null)
+                {
+                    settings.CloudTokens.Remove(key);
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(tokenSet.AccessToken))
+                {
+                    tokenSet.AccessToken = DataProtector.Protect(tokenSet.AccessToken);
+                }
+
+                if (!string.IsNullOrEmpty(tokenSet.RefreshToken))
+                {
+                    tokenSet.RefreshToken = DataProtector.Protect(tokenSet.RefreshToken);
+                }
+            }
         }
 
         private void UnprotectSecrets(AppSettings settings)


### PR DESCRIPTION
## Summary

Implements the first safety-focused slice of the production hardening roadmap on `hardening-phase-1-safety`.

### Changes

- Harden Playit agent download path:
  - stage download before promotion
  - validate signed executable before use
  - leave an explicit pinned SHA256 hook for a verified upstream checksum
- Stop deleting `world/session.lock` automatically:
  - warn in logs/console instead
  - preserve the world safety marker to avoid masking active-world corruption risks
- Make server process registration atomic with `TryAdd`.
- Log server stream reader failures instead of swallowing all exceptions.
- Validate Bedrock `level-name` before resolving backup/restore world paths.
- Save settings through a protected clone under a lock instead of mutating the live settings object.
- Escape Google Drive query string literals for folder names and parent IDs.

## Notes

I could not verify Playit's authoritative SHA256 from upstream inside this environment, so this PR uses signed-file validation and keeps `PlayitExpectedSha256` as a nullable constant for a future pinned checksum. Once the verified SHA256 is obtained, set it and the existing download path will enforce it.

## Verification needed

Please run locally/CI:

```bash
dotnet restore
dotnet build PocketMC.Desktop.sln -c Debug
dotnet build PocketMC.Desktop.sln -c Release
dotnet test PocketMC.Desktop.sln
```

Manual smoke checks recommended:

1. Start a Java server with an existing `world/session.lock` and confirm PocketMC warns but does not delete it.
2. Trigger Playit first-run download and confirm signed executable validation succeeds.
3. Test Bedrock backup/restore with a normal `level-name`.
4. Test unsafe Bedrock `level-name` values such as `../escape` and confirm backup/restore refuses safely.
5. Save/load settings with API keys and OAuth tokens and confirm values are protected on disk but readable in app.
6. Test Google Drive backup with an instance name containing an apostrophe.

## Risk

Medium. These are safety changes in sensitive areas: downloads, settings, process lifecycle, backup/restore, and cloud provider queries. Review carefully before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session lock detection and reporting during server startup
  * Enhanced backup creation validation for Bedrock level names
  * Strengthened Google Drive query safety with proper escaping
  * Better resource cleanup on failed server startup

* **Improvements**
  * Refined settings encryption and persistence handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PocketMC/pocket-mc-windows/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->