### PR TITLE
Phase 2 workflow cleanup: introduce instance creation state service

### DIFF
--- a/PocketMC.Desktop/Composition/ServiceCollectionExtensions.cs
+++ b/PocketMC.Desktop/Composition/ServiceCollectionExtensions.cs
@@ -227,6 +227,7 @@ namespace PocketMC.Desktop.Composition
             services.AddSingleton<ShellStartupCoordinator>();
             services.AddSingleton<ShellViewModel>();
             services.AddSingleton<TrayIconViewModel>();
+            services.AddSingleton<InstanceCreationStateService>();
 
             services.AddTransient<MainWindow>();
             services.AddTransient<JavaSetupPage>();

--- a/PocketMC.Desktop/Features/InstanceCreation/InstanceCreationStateService.cs
+++ b/PocketMC.Desktop/Features/InstanceCreation/InstanceCreationStateService.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace PocketMC.Desktop.Features.InstanceCreation;
+
+/// <summary>
+/// Tracks app-wide instance creation state without relying on static page flags.
+/// </summary>
+public sealed class InstanceCreationStateService
+{
+    private readonly object _gate = new();
+    private bool _isPageOpen;
+    private bool _isCreationInProgress;
+
+    public event Action? StateChanged;
+
+    public bool IsPageOpen
+    {
+        get { lock (_gate) return _isPageOpen; }
+    }
+
+    public bool IsCreationInProgress
+    {
+        get { lock (_gate) return _isCreationInProgress; }
+    }
+
+    public bool ShouldBlockNavigationAway
+    {
+        get { lock (_gate) return _isPageOpen && _isCreationInProgress; }
+    }
+
+    public void SetPageOpen(bool isOpen) => Update(isPageOpen: isOpen, isCreationInProgress: _isCreationInProgress);
+
+    public void SetCreationInProgress(bool isInProgress) => Update(isPageOpen: _isPageOpen, isCreationInProgress: isInProgress);
+
+    public void Reset() => Update(isPageOpen: false, isCreationInProgress: false);
+
+    private void Update(bool isPageOpen, bool isCreationInProgress)
+    {
+        bool changed;
+        lock (_gate)
+        {
+            changed = _isPageOpen != isPageOpen || _isCreationInProgress != isCreationInProgress;
+            _isPageOpen = isPageOpen;
+            _isCreationInProgress = isCreationInProgress;
+        }
+
+        if (changed)
+        {
+            StateChanged?.Invoke();
+        }
+    }
+}

--- a/PocketMC.Desktop/Features/Shell/MainWindow.xaml.cs
+++ b/PocketMC.Desktop/Features/Shell/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using PocketMC.Desktop.Core.Interfaces;
 using PocketMC.Desktop.Features.Shell.Interfaces;
 using PocketMC.Desktop.Features.Dashboard;
+using PocketMC.Desktop.Features.InstanceCreation;
 using PocketMC.Desktop.Features.Tunnel;
 using PocketMC.Desktop.Features.Setup;
 using PocketMC.Desktop.Features.Instances.Services;
@@ -24,6 +25,7 @@ public partial class MainWindow : FluentWindow, IShellHost, IStartupShellHost
     private readonly IShellVisualService _visualService;
     private readonly ShellStartupCoordinator _startupCoordinator;
     private readonly ShellViewModel _viewModel;
+    private readonly InstanceCreationStateService _instanceCreationState;
     private readonly ILogger<MainWindow> _logger;
 
     private Type _lastShellPageType = typeof(DashboardPage);
@@ -37,6 +39,7 @@ public partial class MainWindow : FluentWindow, IShellHost, IStartupShellHost
         IShellVisualService visualService,
         ShellStartupCoordinator startupCoordinator,
         ShellViewModel viewModel,
+        InstanceCreationStateService instanceCreationState,
         ILogger<MainWindow> logger)
     {
         _serviceProvider = serviceProvider;
@@ -44,6 +47,7 @@ public partial class MainWindow : FluentWindow, IShellHost, IStartupShellHost
         _visualService = visualService;
         _startupCoordinator = startupCoordinator;
         _viewModel = viewModel;
+        _instanceCreationState = instanceCreationState;
         _logger = logger;
 
         DataContext = _viewModel;
@@ -153,8 +157,7 @@ public partial class MainWindow : FluentWindow, IShellHost, IStartupShellHost
             return;
         }
 
-        if (PocketMC.Desktop.Features.InstanceCreation.NewInstancePage.InstanceCreatePageIsOpen && 
-            PocketMC.Desktop.Features.InstanceCreation.NewInstancePage.IsDownloadInProgress)
+        if (_instanceCreationState.ShouldBlockNavigationAway)
         {
             args.Cancel = true;
             return;
@@ -323,8 +326,7 @@ public partial class MainWindow : FluentWindow, IShellHost, IStartupShellHost
     private void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
         bool downloadExitConfirmed = false;
-        if (PocketMC.Desktop.Features.InstanceCreation.NewInstancePage.InstanceCreatePageIsOpen && 
-            PocketMC.Desktop.Features.InstanceCreation.NewInstancePage.IsDownloadInProgress)
+        if (_instanceCreationState.IsCreationInProgress)
         {
             var result = Infrastructure.AppDialog.Confirm(
                 "Cancel Download?",

--- a/PocketMC.Desktop/Features/Shell/MainWindow.xaml.cs
+++ b/PocketMC.Desktop/Features/Shell/MainWindow.xaml.cs
@@ -157,7 +157,7 @@ public partial class MainWindow : FluentWindow, IShellHost, IStartupShellHost
             return;
         }
 
-        if (_instanceCreationState.ShouldBlockNavigationAway)
+        if (IsInstanceCreationBusy())
         {
             args.Cancel = true;
             return;
@@ -169,6 +169,13 @@ public partial class MainWindow : FluentWindow, IShellHost, IStartupShellHost
         if (_serviceProvider.GetService<IAppNavigationService>() is { } nav)
             nav.NavigateToShellPage(pageType!);
     }
+
+    private bool IsInstanceCreationBusy() =>
+        _instanceCreationState.ShouldBlockNavigationAway ||
+        (NewInstancePage.InstanceCreatePageIsOpen && NewInstancePage.IsDownloadInProgress);
+
+    private bool IsInstanceCreationInProgress() =>
+        _instanceCreationState.IsCreationInProgress || NewInstancePage.IsDownloadInProgress;
 
     private void SyncNavigationSelection(Type? pageType)
     {
@@ -326,7 +333,7 @@ public partial class MainWindow : FluentWindow, IShellHost, IStartupShellHost
     private void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
         bool downloadExitConfirmed = false;
-        if (_instanceCreationState.IsCreationInProgress)
+        if (IsInstanceCreationInProgress())
         {
             var result = Infrastructure.AppDialog.Confirm(
                 "Cancel Download?",


### PR DESCRIPTION
## Summary

Starts Phase 2 workflow cleanup as a stacked branch on top of Phase 1 hardening.

This PR does **not** fully extract `NewInstancePage` into a workflow service yet. That file is large and risky to rewrite through connector-level full-file edits, so this PR takes the safer first step: introduce injectable state tracking and wire the shell to it in a backward-compatible way.

### Changes

- Added `InstanceCreationStateService` to track instance creation page/open/download state without requiring static page flags long-term.
- Registered `InstanceCreationStateService` in DI.
- Updated `MainWindow` to accept the state service.
- Added shell helpers for instance-creation busy checks.
- Kept compatibility fallback to the existing `NewInstancePage.InstanceCreatePageIsOpen` and `NewInstancePage.IsDownloadInProgress` flags until the page workflow is extracted.

## Why this is stacked

Base branch should be `hardening-phase-1-safety`, not `master`, because Phase 2 builds on the Phase 1 safety branch.

## Follow-up work

Next Phase 2 PR should:

1. Inject `InstanceCreationStateService` into `NewInstancePage`.
2. Remove static state from `NewInstancePage`.
3. Extract `CreateInstanceWorkflowService`.
4. Move download/provision/world import/property write cleanup logic out of code-behind.
5. Add workflow-level tests.

## Verification needed

```bash
dotnet restore
dotnet build PocketMC.Desktop.sln -c Debug
dotnet build PocketMC.Desktop.sln -c Release
dotnet test PocketMC.Desktop.sln
```

Manual checks:

- Navigate away during instance creation and confirm navigation is still blocked.
- Close window during instance creation and confirm cancel prompt still appears.
- Confirm normal navigation works when no instance creation is active.

## Risk

Low-medium. This changes shell constructor dependencies and navigation/close checks. It is intentionally backward-compatible to reduce breakage while preparing for full workflow extraction.