### PR TITLE
Final critical hardening: pin Playit checksum and add support bundle foundation

### DIFF
--- a/PocketMC.Desktop.Tests/SupportBundleRedactorTests.cs
+++ b/PocketMC.Desktop.Tests/SupportBundleRedactorTests.cs
@@ -1,0 +1,21 @@
+using PocketMC.Desktop.Features.Diagnostics;
+
+namespace PocketMC.Desktop.Tests;
+
+public sealed class SupportBundleRedactorTests
+{
+    [Fact]
+    public void Redact_RemovesCommonSecretLikeValues()
+    {
+        var redactor = new SupportBundleRedactor();
+        string input = "api_key=abc123\naccess_token: xyz789\nAuthorization: Bearer token-value\nuser@example.com";
+
+        string output = redactor.Redact(input);
+
+        Assert.DoesNotContain("abc123", output);
+        Assert.DoesNotContain("xyz789", output);
+        Assert.DoesNotContain("token-value", output);
+        Assert.DoesNotContain("user@example.com", output);
+        Assert.Contains("[REDACTED", output);
+    }
+}

--- a/PocketMC.Desktop/Composition/ServiceCollectionExtensions.cs
+++ b/PocketMC.Desktop/Composition/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using PocketMC.Desktop.Core.Interfaces;
 using PocketMC.Desktop.Features.Dashboard;
 using PocketMC.Desktop.Features.Console;
+using PocketMC.Desktop.Features.Diagnostics;
 using PocketMC.Desktop.Features.InstanceCreation;
 using PocketMC.Desktop.Features.Instances.Services;
 using PocketMC.Desktop.Features.Instances.Models;
@@ -124,9 +125,11 @@ namespace PocketMC.Desktop.Composition
             services.AddSingleton<ServerConfigurationService>();
             services.AddSingleton<ServerRuntimeSettingApplier>();
             services.AddSingleton<WorldManager>();
-            services.AddSingleton<PocketMC.Desktop.Features.Diagnostics.PortDiagnosticsSnapshotBuilder>();
-            services.AddSingleton<PocketMC.Desktop.Features.Diagnostics.DiagnosticReportingService>();
-            services.AddSingleton<PocketMC.Desktop.Features.Diagnostics.DependencyHealthMonitor>();
+            services.AddSingleton<PortDiagnosticsSnapshotBuilder>();
+            services.AddSingleton<DiagnosticReportingService>();
+            services.AddSingleton<DependencyHealthMonitor>();
+            services.AddSingleton<SupportBundleRedactor>();
+            services.AddSingleton<SupportBundleService>();
             
             services.AddSingleton<PhpProvisioningService>();
             services.AddSingleton<GeyserProvisioningService>();

--- a/PocketMC.Desktop/Features/Diagnostics/SupportBundleRedactor.cs
+++ b/PocketMC.Desktop/Features/Diagnostics/SupportBundleRedactor.cs
@@ -1,0 +1,46 @@
+using System.Text.RegularExpressions;
+
+namespace PocketMC.Desktop.Features.Diagnostics;
+
+public sealed class SupportBundleRedactor
+{
+    private static readonly Regex[] SecretPatterns =
+    {
+        new(@"(?i)(api[_-]?key|access[_-]?token|refresh[_-]?token|agent[_-]?secret[_-]?key|client[_-]?secret|authorization|bearer)\s*[:=]\s*['"" ]?[^'""\r\n,}]+", RegexOptions.Compiled | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1)),
+        new(@"(?i)(Authorization:\s*Bearer\s+)[A-Za-z0-9._\-]+", RegexOptions.Compiled | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1)),
+        new(@"(?i)(dpapi:v1:)[A-Za-z0-9+/=]+", RegexOptions.Compiled | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1)),
+        new(@"(?i)(playit[^\r\n]*(secret|token|agent)[^\r\n]*[:=]\s*)[^\r\n]+", RegexOptions.Compiled | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1))
+    };
+
+    private static readonly Regex EmailPattern = new(
+        @"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
+    public string Redact(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return string.Empty;
+        }
+
+        string redacted = input;
+        foreach (var pattern in SecretPatterns)
+        {
+            redacted = pattern.Replace(redacted, match =>
+            {
+                string value = match.Value;
+                int separatorIndex = Math.Max(value.LastIndexOf('='), value.LastIndexOf(':'));
+                if (separatorIndex <= 0 || separatorIndex >= value.Length - 1)
+                {
+                    return "[REDACTED_SECRET]";
+                }
+
+                return value[..(separatorIndex + 1)] + " [REDACTED]";
+            });
+        }
+
+        redacted = EmailPattern.Replace(redacted, "[REDACTED_EMAIL]");
+        return redacted;
+    }
+}

--- a/PocketMC.Desktop/Features/Diagnostics/SupportBundleService.cs
+++ b/PocketMC.Desktop/Features/Diagnostics/SupportBundleService.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -98,7 +100,9 @@ OS64Bit: {Environment.Is64BitOperatingSystem}
             settings.AlwaysAutoSummarize,
             settings.ConsoleBufferSize,
             settings.EnableDiscordRpc,
-            CloudBackupsEnabled = settings.CloudBackups?.Providers?.Any(p => p.IsEnabled) == true
+            CloudBackupsEnabled = settings.CloudBackups?.EnableCloudBackups == true,
+            CloudBackupTargetCount = settings.CloudBackups?.Targets?.Count ?? 0,
+            EnabledCloudBackupTargetCount = settings.CloudBackups?.Targets?.Count(t => t.Enabled) ?? 0
         };
 
         string json = JsonSerializer.Serialize(safe, new JsonSerializerOptions { WriteIndented = true });

--- a/PocketMC.Desktop/Features/Diagnostics/SupportBundleService.cs
+++ b/PocketMC.Desktop/Features/Diagnostics/SupportBundleService.cs
@@ -1,0 +1,176 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using PocketMC.Desktop.Features.Instances.Services;
+using PocketMC.Desktop.Features.Settings;
+
+namespace PocketMC.Desktop.Features.Diagnostics;
+
+public sealed class SupportBundleService
+{
+    private const long MaxCopiedFileBytes = 2 * 1024 * 1024;
+    private readonly SettingsManager _settingsManager;
+    private readonly InstanceRegistry _instanceRegistry;
+    private readonly SupportBundleRedactor _redactor;
+    private readonly ILogger<SupportBundleService> _logger;
+
+    public SupportBundleService(
+        SettingsManager settingsManager,
+        InstanceRegistry instanceRegistry,
+        SupportBundleRedactor redactor,
+        ILogger<SupportBundleService> logger)
+    {
+        _settingsManager = settingsManager;
+        _instanceRegistry = instanceRegistry;
+        _redactor = redactor;
+        _logger = logger;
+    }
+
+    public async Task<string> CreateAsync(string destinationDirectory, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(destinationDirectory))
+            throw new ArgumentException("Destination directory cannot be empty.", nameof(destinationDirectory));
+
+        Directory.CreateDirectory(destinationDirectory);
+        string stagingDir = Path.Combine(Path.GetTempPath(), $"PocketMC-support-{Guid.NewGuid():N}");
+        string zipPath = Path.Combine(destinationDirectory, $"PocketMC-support-{DateTime.UtcNow:yyyyMMdd-HHmmss}.zip");
+
+        try
+        {
+            Directory.CreateDirectory(stagingDir);
+            await WriteSummaryAsync(stagingDir, cancellationToken);
+            await WriteSanitizedSettingsAsync(stagingDir, cancellationToken);
+            await WriteInstanceSummaryAsync(stagingDir, cancellationToken);
+            await CopyKnownDiagnosticsAsync(stagingDir, cancellationToken);
+
+            if (File.Exists(zipPath)) File.Delete(zipPath);
+            ZipFile.CreateFromDirectory(stagingDir, zipPath, CompressionLevel.Fastest, includeBaseDirectory: false);
+            return zipPath;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create support bundle.");
+            throw;
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(stagingDir)) Directory.Delete(stagingDir, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to clean up support bundle staging directory {StagingDir}.", stagingDir);
+            }
+        }
+    }
+
+    private static Task WriteSummaryAsync(string stagingDir, CancellationToken cancellationToken)
+    {
+        string summary = $"""
+PocketMC Support Bundle
+GeneratedUtc: {DateTime.UtcNow:O}
+OS: {Environment.OSVersion}
+DotNet: {Environment.Version}
+Process64Bit: {Environment.Is64BitProcess}
+OS64Bit: {Environment.Is64BitOperatingSystem}
+""";
+        return File.WriteAllTextAsync(Path.Combine(stagingDir, "summary.txt"), summary, cancellationToken);
+    }
+
+    private async Task WriteSanitizedSettingsAsync(string stagingDir, CancellationToken cancellationToken)
+    {
+        var settings = _settingsManager.Load();
+        var safe = new
+        {
+            settings.SchemaVersion,
+            HasAppRootPath = !string.IsNullOrWhiteSpace(settings.AppRootPath),
+            settings.HasCompletedFirstLaunch,
+            settings.StartWithWindows,
+            settings.StartMinimizedToTray,
+            settings.MinimizeToTrayOnClose,
+            settings.WindowBackdrop,
+            HasCurseForgeKey = !string.IsNullOrWhiteSpace(settings.CurseForgeApiKey),
+            settings.EnableAiSummarization,
+            settings.AiProvider,
+            HasAiKey = !string.IsNullOrWhiteSpace(settings.GetCurrentAiKey()),
+            settings.AlwaysAutoSummarize,
+            settings.ConsoleBufferSize,
+            settings.EnableDiscordRpc,
+            CloudBackupsEnabled = settings.CloudBackups?.Providers?.Any(p => p.IsEnabled) == true
+        };
+
+        string json = JsonSerializer.Serialize(safe, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(Path.Combine(stagingDir, "settings-summary.json"), json, cancellationToken);
+    }
+
+    private async Task WriteInstanceSummaryAsync(string stagingDir, CancellationToken cancellationToken)
+    {
+        var instances = _instanceRegistry.GetAll()
+            .Select(instance => new
+            {
+                instance.SchemaVersion,
+                instance.Id,
+                instance.Name,
+                instance.ServerType,
+                instance.MinecraftVersion,
+                instance.LoaderVersion,
+                instance.CreatedAt,
+                instance.LastPlayedAt,
+                instance.MinRamMb,
+                instance.MaxRamMb,
+                instance.HasGeyser,
+                instance.GeyserBedrockPort,
+                instance.ServerPort,
+                instance.BackupIntervalHours,
+                instance.MaxBackupsToKeep,
+                instance.LastBackupTime,
+                instance.EnableAutoRestart,
+                HasCustomJavaPath = !string.IsNullOrWhiteSpace(instance.CustomJavaPath),
+                HasAdvancedJvmArgs = !string.IsNullOrWhiteSpace(instance.AdvancedJvmArgs),
+                instance.SimpleVoiceChatDetected,
+                instance.SimpleVoiceChatPort,
+                HasSimpleVoiceChatTunnel = !string.IsNullOrWhiteSpace(instance.SimpleVoiceChatTunnelId),
+                instance.SimpleVoiceChatStatus
+            })
+            .ToList();
+
+        string json = JsonSerializer.Serialize(instances, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(Path.Combine(stagingDir, "instances-summary.json"), json, cancellationToken);
+    }
+
+    private async Task CopyKnownDiagnosticsAsync(string stagingDir, CancellationToken cancellationToken)
+    {
+        string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        string pocketMcDir = Path.Combine(localAppData, "PocketMC");
+        if (!Directory.Exists(pocketMcDir)) return;
+
+        string diagnosticsDir = Path.Combine(stagingDir, "diagnostics");
+        Directory.CreateDirectory(diagnosticsDir);
+
+        foreach (string candidateDir in new[] { "logs", "CrashReports" })
+        {
+            string sourceDir = Path.Combine(pocketMcDir, candidateDir);
+            if (!Directory.Exists(sourceDir)) continue;
+
+            string targetDir = Path.Combine(diagnosticsDir, candidateDir);
+            Directory.CreateDirectory(targetDir);
+            foreach (string file in Directory.EnumerateFiles(sourceDir).OrderByDescending(File.GetLastWriteTimeUtc).Take(20))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await CopyRedactedTextFileAsync(file, Path.Combine(targetDir, Path.GetFileName(file)), cancellationToken);
+            }
+        }
+    }
+
+    private async Task CopyRedactedTextFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken)
+    {
+        var info = new FileInfo(sourcePath);
+        if (!info.Exists || info.Length > MaxCopiedFileBytes) return;
+
+        string content = await File.ReadAllTextAsync(sourcePath, cancellationToken);
+        string redacted = _redactor.Redact(content);
+        await File.WriteAllTextAsync(destinationPath, redacted, Encoding.UTF8, cancellationToken);
+    }
+}

--- a/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
+++ b/PocketMC.Desktop/Features/Instances/Services/DownloaderService.cs
@@ -15,10 +15,7 @@ namespace PocketMC.Desktop.Features.Instances.Services;
         private const string DownloadClientName = "PocketMC.Downloads";
         private const string PlayitAgentVersion = "0.17.1";
         private const string PlayitDownloadUrl = "https://github.com/playit-cloud/playit-agent/releases/download/v0.17.1/playit-windows-x86_64-signed.exe";
-
-        // Playit does not currently expose a stable checksum in the app's source of truth.
-        // Keep this nullable until a verified upstream SHA256 is recorded, then fail closed on mismatch.
-        private const string? PlayitExpectedSha256 = null;
+        private const string? PlayitExpectedSha256 = "9b00d6ff7d37d1052e5ae097e1348e11deae8617cd7a8ba39d1777f2006316a3";
 
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<DownloaderService> _logger;


### PR DESCRIPTION
## Summary

Adds the final low-risk hardening items that can be safely implemented on top of the existing stacked PR chain.

### Changes

- Carries the verified Playit `v0.17.1` SHA256 pin into the top hardening branch.
- Adds `SupportBundleRedactor` for sanitizing diagnostic text.
- Adds `SupportBundleService` for creating a safe support ZIP containing:
  - environment summary
  - sanitized settings summary
  - sanitized instance summary
  - redacted local logs/crash reports, size-limited
- Registers support bundle services in DI.
- Adds redaction unit test coverage.

## What this closes

This moves the Playit download issue from partial to fixed because the downloaded executable is now version-pinned and SHA256-pinned.

It also materially improves observability/debuggability by adding a real support bundle foundation instead of relying only on docs.

## Still not fully closed

Two original review findings still require larger dedicated PRs:

1. `NewInstancePage.xaml.cs` still needs full `CreateInstanceWorkflowService` extraction.
2. Marketplace/provider failures still need typed result propagation through service and UI call sites, not only shared operation result contracts.

Those should not be faked in this PR with superficial wrappers.

## Verification needed

```bash
dotnet restore PocketMC.Desktop.sln
dotnet build PocketMC.Desktop.sln -c Debug --no-restore
dotnet build PocketMC.Desktop.sln -c Release --no-restore
dotnet test PocketMC.Desktop.sln --no-build
dotnet list PocketMC.Desktop.sln package --vulnerable --include-transitive
```

Manual smoke checks:

- Trigger Playit first-run download and verify hash check succeeds.
- Tamper with the downloaded Playit executable and verify validation rejects it.
- Create a support bundle and inspect that it does not include raw secrets or full settings.

## Risk

Medium. Playit checksum pinning is intentionally strict: if upstream replaces the asset without changing the version, PocketMC will reject the download. That is the correct fail-closed behavior.