### PR TITLE
feat(ux): implement broad UI/UX architecture improvements

### DIFF
--- a/PocketMC.Desktop/Features/Console/ServerConsolePage.ResponsiveToolbar.cs
+++ b/PocketMC.Desktop/Features/Console/ServerConsolePage.ResponsiveToolbar.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+
+namespace PocketMC.Desktop.Features.Console
+{
+    public partial class ServerConsolePage
+    {
+        private bool _responsiveToolbarInstalled;
+        private WrapPanel? _responsiveToolbar;
+
+        protected override void OnInitialized(EventArgs e)
+        {
+            base.OnInitialized(e);
+            Loaded += ServerConsolePage_ResponsiveToolbarLoaded;
+        }
+
+        private void ServerConsolePage_ResponsiveToolbarLoaded(object sender, RoutedEventArgs e)
+        {
+            InstallResponsiveToolbar();
+            UpdateReadOnlyCommandHint();
+        }
+
+        private void InstallResponsiveToolbar()
+        {
+            if (_responsiveToolbarInstalled || PageRoot == null)
+            {
+                return;
+            }
+
+            UIElement? originalToolbar = null;
+            foreach (UIElement child in PageRoot.Children)
+            {
+                if (Grid.GetRow(child) == 0)
+                {
+                    originalToolbar = child;
+                    break;
+                }
+            }
+
+            if (originalToolbar != null)
+            {
+                originalToolbar.Visibility = Visibility.Collapsed;
+            }
+
+            _responsiveToolbar = new WrapPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 0, 0, 12)
+            };
+            Grid.SetRow(_responsiveToolbar, 0);
+
+            _responsiveToolbar.Children.Add(MakeUiButton("Back", Wpf.Ui.Controls.SymbolRegular.ArrowLeft24, Wpf.Ui.Controls.ControlAppearance.Secondary, BtnBack_Click));
+
+            var search = new Wpf.Ui.Controls.TextBox
+            {
+                PlaceholderText = "Search logs...",
+                MinWidth = 220,
+                MaxWidth = 360,
+                Margin = ToolbarMargin,
+                Text = TxtLogSearch?.Text ?? string.Empty
+            };
+            search.TextChanged += (_, _) =>
+            {
+                if (TxtLogSearch != null && !string.Equals(TxtLogSearch.Text, search.Text, StringComparison.Ordinal))
+                {
+                    TxtLogSearch.Text = search.Text;
+                }
+            };
+            _responsiveToolbar.Children.Add(search);
+
+            var regex = new ToggleButton
+            {
+                Content = ".*",
+                Width = 34,
+                Height = 34,
+                Padding = new Thickness(0),
+                ToolTip = "Use Regex",
+                Margin = ToolbarMargin
+            };
+            regex.SetBinding(ToggleButton.IsCheckedProperty, new Binding(nameof(IsRegexEnabled)) { Source = this, Mode = BindingMode.TwoWay });
+            _responsiveToolbar.Children.Add(regex);
+
+            _responsiveToolbar.Children.Add(new ToggleButton
+            {
+                Content = "Auto-scroll",
+                IsChecked = BtnAutoScroll?.IsChecked ?? true,
+                Padding = new Thickness(12, 5, 12, 5),
+                Margin = ToolbarMargin
+            });
+
+            _responsiveToolbar.Children.Add(MakeUiButton("Copy Logs", Wpf.Ui.Controls.SymbolRegular.Copy24, Wpf.Ui.Controls.ControlAppearance.Secondary, BtnCopyLogs_Click));
+
+            var filter = new ComboBox
+            {
+                Width = 132,
+                MinHeight = 34,
+                Margin = ToolbarMargin,
+                ToolTip = "Quick log filter"
+            };
+            filter.Items.Add("All");
+            filter.Items.Add("Chat");
+            filter.Items.Add("Info");
+            filter.Items.Add("Warnings");
+            filter.Items.Add("Errors");
+            filter.Items.Add("System");
+            filter.SelectedIndex = 0;
+            filter.SelectionChanged += (_, _) => ApplyQuickFilter(filter.SelectedItem?.ToString() ?? "All");
+            _responsiveToolbar.Children.Add(filter);
+
+            var players = MakeUiButton(PlayerStatus, Wpf.Ui.Controls.SymbolRegular.People24, Wpf.Ui.Controls.ControlAppearance.Secondary, BtnPlayers_Click);
+            players.SetBinding(ContentControl.ContentProperty, new Binding(nameof(PlayerStatus)) { Source = this });
+            players.SetBinding(UIElement.IsEnabledProperty, new Binding(nameof(CanUseLiveServerControls)) { Source = this });
+            _responsiveToolbar.Children.Add(players);
+
+            var stop = MakeUiButton("Stop Server", Wpf.Ui.Controls.SymbolRegular.Stop24, Wpf.Ui.Controls.ControlAppearance.Danger, BtnStop_Click);
+            stop.SetBinding(UIElement.IsEnabledProperty, new Binding(nameof(CanStopServer)) { Source = this });
+            _responsiveToolbar.Children.Add(stop);
+
+            var restart = MakeUiButton("Restart", Wpf.Ui.Controls.SymbolRegular.ArrowSync24, Wpf.Ui.Controls.ControlAppearance.Secondary, BtnRestart_Click);
+            restart.SetBinding(UIElement.IsEnabledProperty, new Binding(nameof(CanUseLiveServerControls)) { Source = this });
+            _responsiveToolbar.Children.Add(restart);
+
+            _responsiveToolbar.Children.Add(MakeUiButton("AI Summary", Wpf.Ui.Controls.SymbolRegular.Sparkle24, Wpf.Ui.Controls.ControlAppearance.Info, SafeAiSummary_Click));
+
+            PageRoot.Children.Add(_responsiveToolbar);
+            _responsiveToolbarInstalled = true;
+        }
+
+        private static Thickness ToolbarMargin => new(0, 0, 8, 8);
+
+        private Wpf.Ui.Controls.Button MakeUiButton(string content, Wpf.Ui.Controls.SymbolRegular symbol, Wpf.Ui.Controls.ControlAppearance appearance, RoutedEventHandler handler)
+        {
+            var button = new Wpf.Ui.Controls.Button
+            {
+                Content = content,
+                Icon = new Wpf.Ui.Controls.SymbolIcon { Symbol = symbol },
+                Appearance = appearance,
+                Margin = ToolbarMargin,
+                Cursor = System.Windows.Input.Cursors.Hand
+            };
+            button.Click += handler;
+            return button;
+        }
+
+        private void ApplyQuickFilter(string filter)
+        {
+            IsFilterChat = filter is "All" or "Chat";
+            IsFilterInfo = filter is "All" or "Info";
+            IsFilterWarn = filter is "All" or "Warnings";
+            IsFilterError = filter is "All" or "Errors";
+            IsFilterSystem = filter is "All" or "System";
+        }
+
+        private void UpdateReadOnlyCommandHint()
+        {
+            if (TxtCommand == null)
+            {
+                return;
+            }
+
+            if (IsReadOnlySessionLog)
+            {
+                TxtCommand.PlaceholderText = "Start the server to send commands";
+            }
+        }
+
+        private async void SafeAiSummary_Click(object sender, RoutedEventArgs e)
+        {
+            bool consent = PocketMC.Desktop.Infrastructure.AppDialog.Confirm(
+                "AI Log Analysis",
+                "This sends selected server logs to your configured AI provider. Logs may include player names, IP addresses, local paths, chat text, or tokens. Continue?");
+
+            if (!consent)
+            {
+                return;
+            }
+
+            await SummarizeSessionAsync();
+        }
+
+        private void BtnOpenServerFolder_Click(object sender, RoutedEventArgs e)
+        {
+            OpenFolder(_instancePath);
+        }
+
+        private void BtnOpenModsFolder_Click(object sender, RoutedEventArgs e)
+        {
+            string modsPath = Path.Combine(_instancePath, "mods");
+            string pluginsPath = Path.Combine(_instancePath, "plugins");
+
+            if (Directory.Exists(modsPath))
+            {
+                OpenFolder(modsPath);
+                return;
+            }
+
+            if (Directory.Exists(pluginsPath))
+            {
+                OpenFolder(pluginsPath);
+                return;
+            }
+
+            OpenFolder(_instancePath);
+        }
+
+        private void OpenFolder(string path)
+        {
+            try
+            {
+                if (!Directory.Exists(path))
+                {
+                    return;
+                }
+
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = path,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                Logs.Add(new LogLine { Text = $"[PocketMC] Could not open folder: {ex.Message}", TextColor = System.Windows.Media.Brushes.OrangeRed, Level = LogLevel.System });
+            }
+        }
+    }
+}

--- a/PocketMC.Desktop/Features/Dashboard/DashboardActionsVM.cs
+++ b/PocketMC.Desktop/Features/Dashboard/DashboardActionsVM.cs
@@ -98,7 +98,7 @@ namespace PocketMC.Desktop.Features.Dashboard
                 if (availableMb < requiredMb + 512)
                 {
                     var result = await _dialogService.ShowDialogAsync("Low Memory",
-                        $"Your system only has {availableMb}MB of available RAM. Starting this server ({requiredMb}MB) might cause significant lag or crashes.\n\nContinue anyway?",
+                        $"Your system only has {availableMb}MB of available RAM. This server is configured for {requiredMb}MB. Starting it anyway may cause lag, crashes, or Windows doing its usual dramatic coughing.\n\nContinue anyway?",
                         DialogType.Warning, true);
                     if (result != DialogResult.Yes)
                     {
@@ -117,7 +117,6 @@ namespace PocketMC.Desktop.Features.Dashboard
 
                 await _lifecycleService.StartAsync(vm.Metadata);
                 vm.ClearPortIssue();
-                // The update state will be handled by listening to OnInstanceStateChanged in DashboardViewModel or CardVM.
                 onStarted(vm);
 
                 _ = _tunnelOrchestrator.EnsureTunnelFlowAsync(vm);
@@ -131,7 +130,7 @@ namespace PocketMC.Desktop.Features.Dashboard
                 vm.UpdateState(ServerState.Stopped);
                 onStarted(vm);
                 _logger.LogError(ex, "Failed to start server {ServerName}.", vm.Name);
-                _dialogService.ShowMessage("Start Failed", $"PocketMC could not start '{vm.Name}'.\n\n{ex.Message}", DialogType.Error);
+                _dialogService.ShowMessage("Start Failed", $"PocketMC could not start '{vm.Name}'.\n\nWhat you can try:\n- Open the console logs\n- Check Java and RAM settings\n- Check whether another server is using the same port\n\nTechnical detail:\n{ex.Message}", DialogType.Error);
             }
         }
 
@@ -149,13 +148,11 @@ namespace PocketMC.Desktop.Features.Dashboard
 
                 if (_lifecycleService.GetProcess(vm.Id) == null) return;
 
-                // Capture session start time before stopping
                 var sessionStart = _lifecycleService.GetSessionStartTime(vm.Id) ?? DateTime.UtcNow;
 
                 vm.UpdateState(ServerState.Stopping);
                 await _lifecycleService.StopAsync(vm.Id);
 
-                // Trigger AI summarization flow after stop completes
                 _ = TriggerAiSummarizationAsync(vm, sessionStart);
             }
             catch (Exception ex)
@@ -173,26 +170,23 @@ namespace PocketMC.Desktop.Features.Dashboard
             {
                 var settings = _applicationState.Settings;
 
-                // Check if feature is enabled and configured
                 if (!settings.EnableAiSummarization || string.IsNullOrWhiteSpace(settings.GetCurrentAiKey()))
                     return;
 
                 string? serverDir = _registry.GetPath(vm.Id);
                 if (serverDir == null) return;
 
-                // Either auto-generate or ask the user
                 if (!settings.AlwaysAutoSummarize)
                 {
                     var response = await _dialogService.ShowDialogAsync(
                         "AI Session Summary",
-                        $"Generate an AI summary for this '{vm.Name}' session?\n\nThis will send the session logs to {settings.AiProvider} for analysis.",
+                        $"Generate an AI summary for this '{vm.Name}' session?\n\nThis sends the session logs to {settings.AiProvider} for analysis. Logs may contain player names, IP addresses, local paths, chat, or tokens. Review your settings before sending anything sensitive. Because apparently computers need privacy warnings now, and honestly, they do.",
                         DialogType.Question, true);
 
                     if (response != DialogResult.Yes)
                         return;
                 }
 
-                // Run summarization asynchronously
                 var summarizationService = (SessionSummarizationService)_serviceProvider.GetService(typeof(SessionSummarizationService))!;
                 var provider = AiApiClient.ParseProvider(settings.AiProvider);
                 var sessionEnd = DateTime.UtcNow;
@@ -215,7 +209,6 @@ namespace PocketMC.Desktop.Features.Dashboard
             catch (Exception ex)
             {
                 _logger.LogError(ex, "AI summarization failed for {Server}.", vm.Name);
-                // Intentionally swallowed — summarization failure must never affect server operations
             }
         }
 
@@ -265,7 +258,7 @@ namespace PocketMC.Desktop.Features.Dashboard
                 vm.UpdateState(ServerState.Stopped);
                 onStarted(vm);
                 _logger.LogError(ex, "Failed to restart server {ServerName}.", vm.Name);
-                _dialogService.ShowMessage("Restart Failed", $"PocketMC could not restart '{vm.Name}'.\n\n{ex.Message}", DialogType.Error);
+                _dialogService.ShowMessage("Restart Failed", $"PocketMC could not restart '{vm.Name}'.\n\nTry opening the console, checking the port, and reviewing Java/RAM settings.\n\nTechnical detail:\n{ex.Message}", DialogType.Error);
             }
         }
 
@@ -273,11 +266,16 @@ namespace PocketMC.Desktop.Features.Dashboard
         {
             if (_lifecycleService.IsRunning(vm.Id))
             {
-                _dialogService.ShowMessage("Server Running", "Cannot delete a running server. Stop it first.", DialogType.Warning);
+                _dialogService.ShowMessage("Server Running", "Cannot delete a running server. Stop it first so PocketMC does not delete files while Java is still hugging them.", DialogType.Warning);
                 return;
             }
 
-            var prompt = await _dialogService.ShowDialogAsync("Delete Server", $"Are you sure you want to completely erase the {vm.Name} server?", DialogType.Warning, false);
+            var prompt = await _dialogService.ShowDialogAsync(
+                "Delete Server Permanently",
+                $"Delete '{vm.Name}' permanently?\n\nThis deletes the server folder, including world files, configuration, installed mods/plugins, and logs. Backups stored outside this server folder are not deleted.\n\nThis cannot be undone. Continue?",
+                DialogType.Warning,
+                true);
+
             if (prompt == DialogResult.Yes)
             {
                 await _lifecycleService.ReleaseInstanceAsync(vm.Id);
@@ -319,7 +317,7 @@ namespace PocketMC.Desktop.Features.Dashboard
                 string? instancePath = _registry.GetPath(vm.Id);
                 if (string.IsNullOrWhiteSpace(instancePath) || !Directory.Exists(instancePath))
                 {
-                    _dialogService.ShowMessage("Export Unavailable", "PocketMC could not find this instance folder.", DialogType.Warning);
+                    _dialogService.ShowMessage("Export Unavailable", "PocketMC could not find this server folder.", DialogType.Warning);
                     return;
                 }
 
@@ -408,7 +406,10 @@ namespace PocketMC.Desktop.Features.Dashboard
                 primary.Request.Protocol,
                 primary.Request.IpMode);
 
-            _dialogService.ShowMessage(displayInfo.Title, displayInfo.Message, DialogType.Warning);
+            _dialogService.ShowMessage(
+                displayInfo.Title,
+                displayInfo.Message + "\n\nFix options:\n- Change this server's port in Settings\n- Stop the other app using the port\n- Open the server folder and inspect logs if the port looks correct",
+                DialogType.Warning);
         }
     }
 }

--- a/PocketMC.Desktop/Features/Dashboard/DashboardPage.xaml
+++ b/PocketMC.Desktop/Features/Dashboard/DashboardPage.xaml
@@ -9,7 +9,6 @@
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
         <presentation:NullOrEmptyToVisibilityConverter x:Key="NullOrEmptyToVis"/>
 
-        <!-- Reusable skeleton placeholder row for tunnel IP resolution -->
         <Style x:Key="SkeletonRow" TargetType="ContentControl">
             <Setter Property="Focusable" Value="False"/>
             <Setter Property="IsTabStop" Value="False"/>
@@ -87,12 +86,34 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Margin="0,0,0,24" Orientation="Horizontal">
-            <ui:TextBlock FontTypography="Title" Text="Instances" Foreground="{DynamicResource TextFillColorPrimaryBrush}" Margin="0,0,16,0" VerticalAlignment="Center"/>
-            <ui:Button Content="New Instance" Icon="{ui:SymbolIcon Add24}" Appearance="Primary" Command="{Binding DataContext.NewInstanceCommand, RelativeSource={RelativeSource AncestorType=Page}}" Cursor="Hand"/>
-        </StackPanel>
+        <Grid Grid.Row="0" Margin="0,0,0,24">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0">
+                <ui:TextBlock FontTypography="Title" Text="Servers" Foreground="{DynamicResource TextFillColorPrimaryBrush}" Margin="0,0,0,4"/>
+                <TextBlock Text="Create, import, start, monitor, and share your Minecraft servers from one place. Somehow civilization continues." FontSize="13" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextWrapping="Wrap"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                <ui:Button Content="Import Server" Icon="{ui:SymbolIcon ArrowUpload24}" Appearance="Secondary" Command="{Binding ImportInstanceCommand}" Cursor="Hand" Margin="0,0,10,0"/>
+                <ui:Button Content="Create Server" Icon="{ui:SymbolIcon Add24}" Appearance="Primary" Command="{Binding NewInstanceCommand}" Cursor="Hand"/>
+            </StackPanel>
+        </Grid>
 
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+        <ui:Card Grid.Row="1" Padding="40" MaxWidth="560" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{Binding EmptyStateVisibility}">
+            <StackPanel HorizontalAlignment="Center">
+                <ui:SymbolIcon Symbol="Cube24" FontSize="42" HorizontalAlignment="Center" Foreground="{DynamicResource SystemFillColorAttentionBrush}" Margin="0,0,0,16"/>
+                <ui:TextBlock FontTypography="Subtitle" Text="No servers yet" HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                <TextBlock Text="Create your first Minecraft server or import an existing one. PocketMC will handle the files, versions, and connection setup so you can avoid the ancient ritual of random ZIP folders." TextWrapping="Wrap" TextAlignment="Center" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,0,0,20"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <ui:Button Content="Create Server" Icon="{ui:SymbolIcon Add24}" Appearance="Primary" Command="{Binding NewInstanceCommand}" Margin="0,0,10,0"/>
+                    <ui:Button Content="Import Server" Icon="{ui:SymbolIcon ArrowUpload24}" Appearance="Secondary" Command="{Binding ImportInstanceCommand}"/>
+                </StackPanel>
+            </StackPanel>
+        </ui:Card>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="{Binding ServerListVisibility}">
             <ItemsControl ItemsSource="{Binding Instances}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
@@ -101,7 +122,7 @@
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <ui:Card Margin="12" Width="340">
+                        <ui:Card Margin="12" Width="360">
                             <ui:Card.Style>
                                 <Style TargetType="ui:Card" BasedOn="{StaticResource {x:Type ui:Card}}">
                                     <Style.Triggers>
@@ -113,14 +134,14 @@
                             </ui:Card.Style>
                             <Grid Margin="4">
                                 <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/> <!-- Header -->
-                                    <RowDefinition Height="Auto"/> <!-- Metadata -->
-                                    <RowDefinition Height="Auto"/> <!-- Metrics -->
-                                    <RowDefinition Height="Auto"/> <!-- Connections -->
-                                    <RowDefinition Height="Auto"/> <!-- Actions -->
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
 
-                                <!-- Header -->
                                 <Grid Grid.Row="0" Margin="0,0,0,12">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
@@ -129,10 +150,10 @@
                                     <StackPanel Grid.Column="0">
                                         <ui:TextBlock FontTypography="Subtitle" Text="{Binding Name}" FontWeight="Bold" TextTrimming="CharacterEllipsis"/>
                                         <WrapPanel Margin="0,6,0,0">
-                                            <Border Background="{DynamicResource ControlFillColorSecondaryBrush}" CornerRadius="4" Padding="6,2" Margin="0,0,4,0">
+                                            <Border Background="{DynamicResource ControlFillColorSecondaryBrush}" CornerRadius="4" Padding="6,2" Margin="0,0,4,0" ToolTip="Minecraft version">
                                                 <TextBlock Text="{Binding MinecraftVersion}" FontSize="10" Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             </Border>
-                                            <Border Background="#3389B4FA" CornerRadius="4" Padding="6,2" Margin="0,0,4,0">
+                                            <Border Background="#3389B4FA" CornerRadius="4" Padding="6,2" Margin="0,0,4,0" ToolTip="Server software type">
                                                 <TextBlock Text="{Binding ServerType}" FontSize="10" Foreground="{DynamicResource SystemFillColorAttentionBrush}" FontWeight="SemiBold"/>
                                             </Border>
                                             <Border Background="#2234D399" BorderBrush="#5534D399" BorderThickness="1" CornerRadius="4" Padding="6,2" Visibility="{Binding CrossPlayBadgeVisibility}" ToolTip="{Binding CrossPlayBadgeTooltip}">
@@ -143,34 +164,34 @@
                                             </Border>
                                         </WrapPanel>
                                         <TextBlock Text="{Binding Description}" FontSize="12" Foreground="SlateGray" Margin="0,4,0,0" TextWrapping="Wrap" MaxHeight="32" TextTrimming="CharacterEllipsis" Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
-                                        <TextBlock Text="{Binding StatusText}" Foreground="{Binding StatusBrush}" FontWeight="Bold" FontSize="11" Margin="0,8,0,0"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                            <TextBlock Text="{Binding StatusText}" Foreground="{Binding StatusBrush}" FontWeight="Bold" FontSize="11" Margin="0,0,10,0"/>
+                                            <TextBlock Text="{Binding HealthSummaryText}" Foreground="{Binding HealthSummaryBrush}" FontSize="11" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                        </StackPanel>
                                     </StackPanel>
                                     <ui:Button Grid.Column="1" Appearance="Transparent" Icon="{ui:SymbolIcon MoreVertical24}" Click="BtnMoreOptions_Click" Tag="{Binding DataContext, RelativeSource={RelativeSource AncestorType=Page}}">
                                         <ui:Button.ContextMenu>
                                             <ContextMenu>
                                                 <MenuItem Header="Copy Crash Report" Command="{Binding PlacementTarget.Tag.CopyCrashReportCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding}" />
                                                 <MenuItem Header="Open Folder" Command="{Binding PlacementTarget.Tag.OpenFolderCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding}" />
-                                                <MenuItem Header="Export Instance" Command="{Binding PlacementTarget.Tag.ExportInstanceCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding}" />
+                                                <MenuItem Header="Export Server" Command="{Binding PlacementTarget.Tag.ExportInstanceCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding}" />
                                                 <Separator/>
-                                                <MenuItem Header="Delete Instance" Command="{Binding PlacementTarget.Tag.DeleteInstanceCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding}" />
+                                                <MenuItem Header="Delete Server" Command="{Binding PlacementTarget.Tag.DeleteInstanceCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding}" />
                                             </ContextMenu>
                                         </ui:Button.ContextMenu>
                                     </ui:Button>
                                 </Grid>
 
-                                <!-- Metadata -->
                                 <Border Grid.Row="1" Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="8" Padding="12,10" Margin="0,0,0,12">
                                     <UniformGrid Columns="3">
                                         <StackPanel Margin="0,0,8,0">
                                             <TextBlock Style="{StaticResource MetadataItemLabel}" Text="Last played"/>
                                             <TextBlock Style="{StaticResource MetadataItemValue}" Text="{Binding LastPlayedValueText}" ToolTip="{Binding LastPlayedTooltip}"/>
                                         </StackPanel>
-
                                         <StackPanel Margin="4,0,4,0" HorizontalAlignment="Stretch">
                                             <TextBlock Style="{StaticResource MetadataItemLabel}" Text="Created" TextAlignment="Center"/>
                                             <TextBlock Style="{StaticResource MetadataItemValue}" Text="{Binding CreatedValueText}" TextAlignment="Center"/>
                                         </StackPanel>
-
                                         <StackPanel Margin="8,0,0,0">
                                             <TextBlock Style="{StaticResource MetadataItemLabel}" Text="Platform" TextAlignment="Right"/>
                                             <TextBlock Style="{StaticResource MetadataItemValue}" Text="{Binding PlatformSummaryText}" TextAlignment="Right"/>
@@ -178,7 +199,6 @@
                                     </UniformGrid>
                                 </Border>
 
-                                <!-- Metrics -->
                                 <Border Grid.Row="2" Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,16">
                                     <UniformGrid Columns="3">
                                         <StackPanel HorizontalAlignment="Center">
@@ -189,16 +209,7 @@
                                             <TextBlock Text="RAM" FontSize="10" Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             <TextBlock Text="{Binding RamText}" FontSize="13" FontWeight="Bold" Foreground="{DynamicResource TextFillColorPrimaryBrush}" HorizontalAlignment="Center"/>
                                         </StackPanel>
-                                        <ui:Button Appearance="Transparent"
-                                                   Padding="12,6"
-                                                   Margin="0,-6"
-                                                   MinWidth="0"
-                                                   HorizontalAlignment="Center"
-                                                   VerticalAlignment="Center"
-                                                   Command="{Binding DataContext.OpenPlayersCommand, RelativeSource={RelativeSource AncestorType=Page}}"
-                                                   CommandParameter="{Binding}"
-                                                   ToolTip="Manage online players"
-                                                   Cursor="Hand">
+                                        <ui:Button Appearance="Transparent" Padding="12,6" Margin="0,-6" MinWidth="0" HorizontalAlignment="Center" VerticalAlignment="Center" Command="{Binding DataContext.OpenPlayersCommand, RelativeSource={RelativeSource AncestorType=Page}}" CommandParameter="{Binding}" ToolTip="Manage online players" Cursor="Hand">
                                             <StackPanel HorizontalAlignment="Center">
                                                 <TextBlock Text="PLAYERS" FontSize="10" Foreground="{DynamicResource TextFillColorSecondaryBrush}" HorizontalAlignment="Center"/>
                                                 <TextBlock Text="{Binding PlayerStatus}" FontSize="13" FontWeight="Bold" Foreground="{DynamicResource TextFillColorPrimaryBrush}" HorizontalAlignment="Center"/>
@@ -207,17 +218,12 @@
                                     </UniformGrid>
                                 </Border>
 
-                                <!-- Connections -->
-                                <StackPanel Grid.Row="3" Margin="0,0,0,16" Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
-
-
-
-                                    <!-- Skeleton: Primary tunnel address -->
+                                <StackPanel Grid.Row="3" Margin="0,0,0,12" Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock Text="Join addresses" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,0,0,6"/>
                                     <ContentControl Style="{StaticResource SkeletonRow}" Visibility="{Binding ShowPrimaryTunnelSkeleton, Converter={StaticResource BoolToVis}}"/>
 
-                                    <!-- Primary Connection (Java or Native Bedrock) -->
-                                    <Border Visibility="{Binding HasTunnelAddress, Converter={StaticResource BoolToVis}}"
-                                            Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Margin="0,0,0,4">                                        <Grid>
+                                    <Border Visibility="{Binding HasTunnelAddress, Converter={StaticResource BoolToVis}}" Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Margin="0,0,0,4">
+                                        <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="*"/>
@@ -237,14 +243,16 @@
                                                     </Style>
                                                 </ui:SymbolIcon.Style>
                                             </ui:SymbolIcon>
-                                            <TextBlock Grid.Column="1" Text="{Binding TunnelAddress}" FontSize="12" Foreground="{DynamicResource TextFillColorPrimaryBrush}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
-                                            <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyIp_Click"/>
+                                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding PrimaryJoinLabel}" FontSize="10" Foreground="{DynamicResource TextFillColorPrimaryBrush}" FontWeight="Bold"/>
+                                                <TextBlock Text="{Binding PrimaryJoinHint}" FontSize="10" Foreground="{DynamicResource TextFillColorTertiaryBrush}" TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock Text="{Binding TunnelAddress}" FontSize="12" Foreground="{DynamicResource TextFillColorPrimaryBrush}" TextTrimming="CharacterEllipsis"/>
+                                            </StackPanel>
+                                            <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyIp_Click" ToolTip="Copy join address"/>
                                         </Grid>
                                     </Border>
 
-                                    <!-- Local Network (LAN) IP -->
-                                    <Border Visibility="{Binding HasLanAddress, Converter={StaticResource BoolToVis}}"
-                                            Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Margin="0,0,0,4">
+                                    <Border Visibility="{Binding HasLanAddress, Converter={StaticResource BoolToVis}}" Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Margin="0,0,0,4">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"/>
@@ -253,20 +261,17 @@
                                             </Grid.ColumnDefinitions>
                                             <ui:SymbolIcon Grid.Column="0" Margin="0,0,8,0" VerticalAlignment="Center" Symbol="Home24" Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                                <TextBlock Text="Local Network (LAN)" FontSize="10" Foreground="{DynamicResource TextFillColorSecondaryBrush}" FontWeight="Bold"/>
+                                                <TextBlock Text="LAN address" FontSize="10" Foreground="{DynamicResource TextFillColorSecondaryBrush}" FontWeight="Bold"/>
+                                                <TextBlock Text="{Binding LanJoinHint}" FontSize="10" Foreground="{DynamicResource TextFillColorTertiaryBrush}" TextTrimming="CharacterEllipsis"/>
                                                 <TextBlock Text="{Binding LanAddressDisplayText}" FontSize="12" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis"/>
                                             </StackPanel>
-                                            <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyLanIp_Click"/>
+                                            <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyLanIp_Click" ToolTip="Copy LAN address"/>
                                         </Grid>
                                     </Border>
 
-                                    <!-- Bedrock-specific Tunnels (Native Bedrock Numeric, or Geyser Hostname + Numeric) -->
                                     <StackPanel Visibility="{Binding IsBedrockServer, Converter={StaticResource BoolToVis}}">
-                                        <!-- Skeleton: Native Bedrock numeric IP -->
                                         <ContentControl Style="{StaticResource SkeletonRow}" Visibility="{Binding ShowBedrockNumericSkeleton, Converter={StaticResource BoolToVis}}"/>
-                                        <!-- Native Bedrock Numeric IP -->
-                                        <Border Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Margin="0,0,0,4"
-                                                Visibility="{Binding HasNumericTunnelAddress, Converter={StaticResource BoolToVis}}">
+                                        <Border Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Margin="0,0,0,4" Visibility="{Binding HasNumericTunnelAddress, Converter={StaticResource BoolToVis}}">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>
@@ -274,18 +279,19 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                 </Grid.ColumnDefinitions>
                                                 <ui:SymbolIcon Grid.Column="0" Symbol="NumberSymbol24" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding NumericTunnelAddress}" FontSize="12" Foreground="{DynamicResource TextFillColorSecondaryBrush}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
-                                                <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyNumericIp_Click"/>
+                                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                                    <TextBlock Text="Numeric fallback" FontSize="10" Foreground="{DynamicResource TextFillColorSecondaryBrush}" FontWeight="Bold"/>
+                                                    <TextBlock Text="{Binding NumericJoinHint}" FontSize="10" Foreground="{DynamicResource TextFillColorTertiaryBrush}" TextTrimming="CharacterEllipsis"/>
+                                                    <TextBlock Text="{Binding NumericTunnelAddress}" FontSize="12" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextTrimming="CharacterEllipsis"/>
+                                                </StackPanel>
+                                                <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyNumericIp_Click" ToolTip="Copy numeric fallback"/>
                                             </Grid>
                                         </Border>
                                     </StackPanel>
 
                                     <StackPanel Visibility="{Binding ShowBedrockIp, Converter={StaticResource BoolToVis}}">
-                                        <!-- Skeleton: Geyser Bedrock hostname -->
                                         <ContentControl Style="{StaticResource SkeletonRow}" Visibility="{Binding ShowGeyserHostnameSkeleton, Converter={StaticResource BoolToVis}}"/>
-                                        <!-- Geyser Bedrock Hostname -->
-                                        <Border Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Margin="0,0,0,4"
-                                                Visibility="{Binding HasBedrockTunnelAddress, Converter={StaticResource BoolToVis}}">
+                                        <Border Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Margin="0,0,0,4" Visibility="{Binding HasBedrockTunnelAddress, Converter={StaticResource BoolToVis}}">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>
@@ -294,15 +300,14 @@
                                                 </Grid.ColumnDefinitions>
                                                 <ui:SymbolIcon Grid.Column="0" Symbol="Cube24" Foreground="{DynamicResource SystemFillColorCautionBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
                                                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                                    <TextBlock Text="Bedrock" FontSize="10" Foreground="{DynamicResource SystemFillColorCautionBrush}" FontWeight="Bold"/>
+                                                    <TextBlock Text="Bedrock via Geyser" FontSize="10" Foreground="{DynamicResource SystemFillColorCautionBrush}" FontWeight="Bold"/>
+                                                    <TextBlock Text="{Binding BedrockJoinHint}" FontSize="10" Foreground="{DynamicResource TextFillColorTertiaryBrush}" TextTrimming="CharacterEllipsis"/>
                                                     <TextBlock Text="{Binding BedrockTunnelAddress}" FontSize="12" Foreground="{DynamicResource SystemFillColorCautionBrush}" TextTrimming="CharacterEllipsis"/>
                                                 </StackPanel>
-                                                <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyBedrockIp_Click"/>
+                                                <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyBedrockIp_Click" ToolTip="Copy Bedrock address"/>
                                             </Grid>
                                         </Border>
-                                        <!-- Skeleton: Geyser Bedrock numeric -->
                                         <ContentControl Style="{StaticResource SkeletonRow}" Visibility="{Binding ShowGeyserNumericSkeleton, Converter={StaticResource BoolToVis}}"/>
-                                        <!-- Geyser Bedrock Numeric -->
                                         <Border Background="{DynamicResource ControlFillColorDefaultBrush}" CornerRadius="6" Padding="10,8" Visibility="{Binding HasBedrockNumericTunnelAddress, Converter={StaticResource BoolToVis}}">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
@@ -311,15 +316,20 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                 </Grid.ColumnDefinitions>
                                                 <ui:SymbolIcon Grid.Column="0" Symbol="NumberSymbol24" Foreground="{DynamicResource SystemFillColorCautionBrush}" Opacity="0.7" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding BedrockNumericTunnelAddress}" FontSize="12" Foreground="{DynamicResource SystemFillColorCautionBrush}" Opacity="0.7" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
-                                                <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyBedrockNumericIp_Click"/>
+                                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                                    <TextBlock Text="Bedrock numeric fallback" FontSize="10" Foreground="{DynamicResource SystemFillColorCautionBrush}" FontWeight="Bold"/>
+                                                    <TextBlock Text="{Binding NumericJoinHint}" FontSize="10" Foreground="{DynamicResource TextFillColorTertiaryBrush}" TextTrimming="CharacterEllipsis"/>
+                                                    <TextBlock Text="{Binding BedrockNumericTunnelAddress}" FontSize="12" Foreground="{DynamicResource SystemFillColorCautionBrush}" Opacity="0.7" TextTrimming="CharacterEllipsis"/>
+                                                </StackPanel>
+                                                <ui:Button Grid.Column="2" Appearance="Transparent" Icon="{ui:SymbolIcon Copy16}" Click="BtnCopyBedrockNumericIp_Click" ToolTip="Copy Bedrock numeric fallback"/>
                                             </Grid>
                                         </Border>
                                     </StackPanel>
                                 </StackPanel>
 
-                                <!-- Actions -->
-                                <Grid Grid.Row="4">
+                                <ui:Button Grid.Row="4" Content="Copy Invite Message" Appearance="Secondary" Icon="{ui:SymbolIcon Copy24}" Click="BtnCopyInvite_Click" Visibility="{Binding ShareInviteVisibility}" Margin="2,0,2,10" HorizontalAlignment="Stretch" ToolTip="Copies a friendly message with the right addresses and version."/>
+
+                                <Grid Grid.Row="5">
                                     <UniformGrid Columns="2" Visibility="{Binding StoppedControlsVisibility}">
                                         <ui:Button Content="Start" Appearance="Primary" Icon="{ui:SymbolIcon Play24}" Command="{Binding DataContext.StartServerCommand, RelativeSource={RelativeSource AncestorType=Page}}" CommandParameter="{Binding}" Margin="2" HorizontalAlignment="Stretch"/>
                                         <ui:Button Content="Logs" Appearance="Secondary" Icon="{ui:SymbolIcon WindowConsole20}" Command="{Binding DataContext.OpenConsoleCommand, RelativeSource={RelativeSource AncestorType=Page}}" CommandParameter="{Binding}" Margin="2" HorizontalAlignment="Stretch"/>

--- a/PocketMC.Desktop/Features/Dashboard/DashboardPage.xaml.cs
+++ b/PocketMC.Desktop/Features/Dashboard/DashboardPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -54,7 +55,7 @@ namespace PocketMC.Desktop.Features.Dashboard
                     string zipPath = files[0];
                     if (zipPath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
                     {
-                        PocketMC.Desktop.Infrastructure.AppDialog.ShowInfo("Info", "Modpack import is now available from Server Settings > Mods.");
+                        PocketMC.Desktop.Infrastructure.AppDialog.ShowInfo("Import Server", "Import existing servers from the Dashboard with Import Server, or install mods from Server Settings > Addons.");
                     }
                 }
             }
@@ -112,6 +113,14 @@ namespace PocketMC.Desktop.Features.Dashboard
             }
         }
 
+        private async void BtnCopyInvite_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement fe && fe.DataContext is InstanceCardViewModel vm)
+            {
+                await TrySetClipboardText(vm.BuildInviteMessage());
+                await ShowCopiedFeedback(fe, "Copied invite");
+            }
+        }
 
         private async Task TrySetClipboardText(string text)
         {
@@ -135,9 +144,27 @@ namespace PocketMC.Desktop.Features.Dashboard
             }
         }
 
-        private async Task ShowCopiedFeedback(FrameworkElement element)
+        private async Task ShowCopiedFeedback(FrameworkElement element, string message = "Copied")
         {
-            // Visual feedback placeholder
+            if (element is Button button)
+            {
+                object? originalContent = button.Content;
+                button.Content = message;
+                await Task.Delay(1200);
+                if (button.Content?.ToString() == message)
+                {
+                    button.Content = originalContent;
+                }
+            }
+            else
+            {
+                element.ToolTip = message;
+                await Task.Delay(1200);
+                if (element.ToolTip?.ToString() == message)
+                {
+                    element.ClearValue(FrameworkElement.ToolTipProperty);
+                }
+            }
         }
 
         private async void BtnCopyBedrockIp_Click(object sender, RoutedEventArgs e)
@@ -148,14 +175,7 @@ namespace PocketMC.Desktop.Features.Dashboard
                 if (addressToCopy.Contains("local") || string.IsNullOrWhiteSpace(addressToCopy)) return;
 
                 await TrySetClipboardText(addressToCopy);
-
-                // Keep the property nulling clean so we can read the raw string for saving
-                vm.BedrockIpDisplayText = "\u2713 Copied";
-                await System.Threading.Tasks.Task.Delay(1500);
-                if (vm.BedrockIpDisplayText == "\u2713 Copied")
-                {
-                    vm.BedrockIpDisplayText = null!; // resets to computed property
-                }
+                await ShowCopiedFeedback(fe);
             }
         }
         private void DashScroller_PreviewMouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)

--- a/PocketMC.Desktop/Features/Dashboard/DashboardViewModel.cs
+++ b/PocketMC.Desktop/Features/Dashboard/DashboardViewModel.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
+using System.Windows;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
 using PocketMC.Desktop.Core.Interfaces;
@@ -38,6 +40,8 @@ namespace PocketMC.Desktop.Features.Dashboard
         private bool _isActive;
 
         public ObservableCollection<InstanceCardViewModel> Instances => _listVm.Instances;
+        public Visibility EmptyStateVisibility => Instances.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility ServerListVisibility => Instances.Count == 0 ? Visibility.Collapsed : Visibility.Visible;
         public ICommand NewInstanceCommand { get; }
         public ICommand ImportInstanceCommand { get; }
         public ICommand RefreshInstancesCommand { get; }
@@ -77,6 +81,8 @@ namespace PocketMC.Desktop.Features.Dashboard
             _serviceProvider = serviceProvider;
             _applicationState = applicationState;
             _playitApiClient = playitApiClient;
+
+            Instances.CollectionChanged += OnInstancesCollectionChanged;
 
             NewInstanceCommand = new RelayCommand(_ => NavigateToNewInstance());
             ImportInstanceCommand = new RelayCommand(_ => NavigateToImportInstance());
@@ -125,6 +131,12 @@ namespace PocketMC.Desktop.Features.Dashboard
             _resourceMonitorService.InstanceMetricsUpdated -= OnInstanceMetricsUpdated;
             _resourceMonitorService.GlobalMetricsUpdated -= OnGlobalMetricsUpdated;
             _isActive = false;
+        }
+
+        private void OnInstancesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(EmptyStateVisibility));
+            OnPropertyChanged(nameof(ServerListVisibility));
         }
 
         private void OnInstancesChanged(object? sender, EventArgs e) => _dispatcher.Invoke(_listVm.LoadInstances);

--- a/PocketMC.Desktop/Features/Dashboard/DashboardViewModel.cs
+++ b/PocketMC.Desktop/Features/Dashboard/DashboardViewModel.cs
@@ -12,6 +12,7 @@ using PocketMC.Desktop.Features.Instances.Services;
 using PocketMC.Desktop.Features.Instances.Models;
 using PocketMC.Desktop.Features.Dashboard;
 using PocketMC.Desktop.Features.InstanceCreation;
+using PocketMC.Desktop.Features.Instances.ImportExport;
 using PocketMC.Desktop.Features.Instances.Backups;
 using PocketMC.Desktop.Features.Tunnel;
 using System.Threading.Tasks;
@@ -38,6 +39,7 @@ namespace PocketMC.Desktop.Features.Dashboard
 
         public ObservableCollection<InstanceCardViewModel> Instances => _listVm.Instances;
         public ICommand NewInstanceCommand { get; }
+        public ICommand ImportInstanceCommand { get; }
         public ICommand RefreshInstancesCommand { get; }
         public ICommand StartServerCommand { get; }
         public ICommand StopServerCommand { get; }
@@ -77,6 +79,7 @@ namespace PocketMC.Desktop.Features.Dashboard
             _playitApiClient = playitApiClient;
 
             NewInstanceCommand = new RelayCommand(_ => NavigateToNewInstance());
+            ImportInstanceCommand = new RelayCommand(_ => NavigateToImportInstance());
             RefreshInstancesCommand = new RelayCommand(_ => _listVm.LoadInstances());
             StartServerCommand = new RelayCommand(p => { if (p is InstanceCardViewModel vm) _actionsVm.StartServer(vm, _metricsVm.ApplyLiveMetrics); });
             StopServerCommand = new RelayCommand(p => { if (p is InstanceCardViewModel vm) _actionsVm.StopServer(vm, _metricsVm.ApplyLiveMetrics); });
@@ -182,7 +185,18 @@ namespace PocketMC.Desktop.Features.Dashboard
         private void NavigateToNewInstance()
         {
             var page = ActivatorUtilities.CreateInstance<NewInstancePage>(_serviceProvider);
-            _navigationService.NavigateToDetailPage(page, "New Instance", DetailRouteKind.NewInstance, DetailBackNavigation.Dashboard, true);
+            _navigationService.NavigateToDetailPage(page, "New Server", DetailRouteKind.NewInstance, DetailBackNavigation.Dashboard, true);
+        }
+
+        private void NavigateToImportInstance()
+        {
+            var page = ActivatorUtilities.CreateInstance<InstanceImportPage>(_serviceProvider);
+            _navigationService.NavigateToDetailPage(
+                page,
+                "Import Server",
+                DetailRouteKind.InstanceImport,
+                DetailBackNavigation.Dashboard,
+                true);
         }
 
         private void UpdateAllLiveMetrics()

--- a/PocketMC.Desktop/Features/Dashboard/InstanceCardViewModel.cs
+++ b/PocketMC.Desktop/Features/Dashboard/InstanceCardViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
+using System.Text;
 using System.Windows;
 using System.Windows.Media;
 using PocketMC.Desktop.Models;
@@ -131,6 +132,40 @@ public class InstanceCardViewModel : INotifyPropertyChanged
     public string? PortIssueText => _portIssueText;
     public string? PortIssueTooltip => _portIssueTooltip;
 
+    public string PrimaryJoinLabel => IsBedrockServer ? "Bedrock join address" : "Java join address";
+    public string PrimaryJoinHint => IsBedrockServer
+        ? "For Bedrock players outside your Wi-Fi."
+        : "For Java players outside your Wi-Fi.";
+    public string LanJoinHint => "For players on the same Wi-Fi/network.";
+    public string BedrockJoinHint => "For Bedrock players joining this Java server through Geyser.";
+    public string NumericJoinHint => "Fallback numeric address for consoles and clients that reject hostnames.";
+    public bool HasAnyShareableAddress => HasTunnelAddress || HasBedrockTunnelAddress || HasNumericTunnelAddress || HasBedrockNumericTunnelAddress || HasLanAddress;
+    public Visibility ShareInviteVisibility => HasAnyShareableAddress ? Visibility.Visible : Visibility.Collapsed;
+
+    public string HealthSummaryText
+    {
+        get
+        {
+            if (HasPortIssue) return "Needs attention: port conflict";
+            if (_state == ServerState.Crashed) return "Needs attention: last run crashed";
+            if (_isTunnelResolving) return "Starting public connection...";
+            if (IsRunning && HasTunnelAddress) return "Healthy: public address ready";
+            if (IsRunning) return "Running: LAN address ready";
+            return "Ready when you are";
+        }
+    }
+
+    public Brush HealthSummaryBrush
+    {
+        get
+        {
+            if (HasPortIssue || _state == ServerState.Crashed) return Brushes.OrangeRed;
+            if (IsRunning && HasTunnelAddress) return Brushes.LimeGreen;
+            if (IsRunning) return Brushes.DeepSkyBlue;
+            return Brushes.Gray;
+        }
+    }
+
     /// <summary>True while the tunnel connect address is being resolved.</summary>
     public bool IsTunnelResolving
     {
@@ -143,6 +178,8 @@ public class InstanceCardViewModel : INotifyPropertyChanged
                 OnPropertyChanged(nameof(ShowBedrockNumericSkeleton));
                 OnPropertyChanged(nameof(ShowGeyserHostnameSkeleton));
                 OnPropertyChanged(nameof(ShowGeyserNumericSkeleton));
+                OnPropertyChanged(nameof(HealthSummaryText));
+                OnPropertyChanged(nameof(HealthSummaryBrush));
             }
         }
     }
@@ -276,6 +313,8 @@ public class InstanceCardViewModel : INotifyPropertyChanged
             {
                 OnPropertyChanged(nameof(HasNumericTunnelAddress));
                 OnPropertyChanged(nameof(ShowBedrockNumericSkeleton));
+                OnPropertyChanged(nameof(HasAnyShareableAddress));
+                OnPropertyChanged(nameof(ShareInviteVisibility));
             }
         }
     }
@@ -290,6 +329,8 @@ public class InstanceCardViewModel : INotifyPropertyChanged
             {
                 OnPropertyChanged(nameof(HasBedrockNumericTunnelAddress));
                 OnPropertyChanged(nameof(ShowGeyserNumericSkeleton));
+                OnPropertyChanged(nameof(HasAnyShareableAddress));
+                OnPropertyChanged(nameof(ShareInviteVisibility));
             }
         }
     }
@@ -321,6 +362,10 @@ public class InstanceCardViewModel : INotifyPropertyChanged
                 OnPropertyChanged(nameof(HasTunnelAddress));
                 OnPropertyChanged(nameof(BedrockIpDisplayText));
                 OnPropertyChanged(nameof(ShowPrimaryTunnelSkeleton));
+                OnPropertyChanged(nameof(HasAnyShareableAddress));
+                OnPropertyChanged(nameof(ShareInviteVisibility));
+                OnPropertyChanged(nameof(HealthSummaryText));
+                OnPropertyChanged(nameof(HealthSummaryBrush));
                 UpdateIpDisplay();
             }
         }
@@ -336,6 +381,8 @@ public class InstanceCardViewModel : INotifyPropertyChanged
                 OnPropertyChanged(nameof(HasBedrockTunnelAddress));
                 OnPropertyChanged(nameof(BedrockIpDisplayText));
                 OnPropertyChanged(nameof(ShowGeyserHostnameSkeleton));
+                OnPropertyChanged(nameof(HasAnyShareableAddress));
+                OnPropertyChanged(nameof(ShareInviteVisibility));
             }
         }
     }
@@ -358,6 +405,43 @@ public class InstanceCardViewModel : INotifyPropertyChanged
     {
         get => VoiceChatTunnelAddress;
         set => VoiceChatTunnelAddress = value;
+    }
+
+    public string BuildInviteMessage()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Join my Minecraft server: {Name}");
+        sb.AppendLine($"Version: {MinecraftVersion}");
+
+        if (HasTunnelAddress)
+        {
+            sb.AppendLine($"{(IsBedrockServer ? "Bedrock" : "Java")}: {TunnelAddress}");
+        }
+        else if (HasLanAddress)
+        {
+            sb.AppendLine($"LAN: {LanAddressDisplayText}");
+        }
+
+        if (ShowBedrockIp && HasBedrockTunnelAddress)
+        {
+            sb.AppendLine($"Bedrock: {BedrockTunnelAddress}");
+        }
+
+        if (IsBedrockServer && HasNumericTunnelAddress)
+        {
+            sb.AppendLine($"Bedrock numeric fallback: {NumericTunnelAddress}");
+        }
+        else if (ShowBedrockIp && HasBedrockNumericTunnelAddress)
+        {
+            sb.AppendLine($"Bedrock numeric fallback: {BedrockNumericTunnelAddress}");
+        }
+
+        if (HasVoiceChatTunnelAddress)
+        {
+            sb.AppendLine($"Simple Voice Chat: {VoiceChatTunnelAddress}");
+        }
+
+        return sb.ToString().TrimEnd();
     }
 
     public void SetSimpleVoiceChatWarning(string warning)
@@ -407,6 +491,10 @@ public class InstanceCardViewModel : INotifyPropertyChanged
             OnPropertyChanged(nameof(StoppedControlsVisibility));
             OnPropertyChanged(nameof(StopButtonText));
             OnPropertyChanged(nameof(HasLanAddress));
+            OnPropertyChanged(nameof(HasAnyShareableAddress));
+            OnPropertyChanged(nameof(ShareInviteVisibility));
+            OnPropertyChanged(nameof(HealthSummaryText));
+            OnPropertyChanged(nameof(HealthSummaryBrush));
         }
     }
 
@@ -418,6 +506,8 @@ public class InstanceCardViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(PortIssueVisibility));
         OnPropertyChanged(nameof(PortIssueText));
         OnPropertyChanged(nameof(PortIssueTooltip));
+        OnPropertyChanged(nameof(HealthSummaryText));
+        OnPropertyChanged(nameof(HealthSummaryBrush));
     }
 
     public void ClearPortIssue()
@@ -433,6 +523,8 @@ public class InstanceCardViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(PortIssueVisibility));
         OnPropertyChanged(nameof(PortIssueText));
         OnPropertyChanged(nameof(PortIssueTooltip));
+        OnPropertyChanged(nameof(HealthSummaryText));
+        OnPropertyChanged(nameof(HealthSummaryBrush));
     }
 
     public void SetBedrockLocalPort(int port)
@@ -503,6 +595,10 @@ public class InstanceCardViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(PrimaryPort));
         OnPropertyChanged(nameof(LanAddressDisplayText));
         OnPropertyChanged(nameof(BedrockIpDisplayText));
+        OnPropertyChanged(nameof(PrimaryJoinLabel));
+        OnPropertyChanged(nameof(PrimaryJoinHint));
+        OnPropertyChanged(nameof(HealthSummaryText));
+        OnPropertyChanged(nameof(HealthSummaryBrush));
     }
 
     /// <summary>

--- a/PocketMC.Desktop/Features/InstanceCreation/NewInstancePage.GoalPresets.cs
+++ b/PocketMC.Desktop/Features/InstanceCreation/NewInstancePage.GoalPresets.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace PocketMC.Desktop.Features.InstanceCreation
+{
+    public partial class NewInstancePage
+    {
+        private bool _goalPresetsInstalled;
+
+        protected override void OnInitialized(EventArgs e)
+        {
+            base.OnInitialized(e);
+            Loaded += NewInstancePage_GoalPresetsLoaded;
+        }
+
+        private void NewInstancePage_GoalPresetsLoaded(object sender, RoutedEventArgs e)
+        {
+            InstallGoalPresetCard();
+        }
+
+        private void InstallGoalPresetCard()
+        {
+            if (_goalPresetsInstalled || ContentLayoutRoot == null)
+            {
+                return;
+            }
+
+            var card = new Wpf.Ui.Controls.Card
+            {
+                Padding = new Thickness(18),
+                Margin = new Thickness(0, 0, 0, 14)
+            };
+
+            var root = new StackPanel();
+            root.Children.Add(new TextBlock
+            {
+                Text = "Start with a goal",
+                FontSize = 14,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = FindResource("TextFillColorPrimaryBrush") as Brush,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            root.Children.Add(new TextBlock
+            {
+                Text = "Pick what you are trying to make. PocketMC will choose sane defaults, since apparently dropdown archaeology is not a hobby most users requested.",
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 12,
+                Foreground = FindResource("TextFillColorSecondaryBrush") as Brush,
+                Margin = new Thickness(0, 0, 0, 12)
+            });
+
+            var presets = new WrapPanel { Orientation = Orientation.Horizontal };
+            presets.Children.Add(MakePresetButton("Survival with friends", "Paper", "Easy", "Survival", enableGeyser: false));
+            presets.Children.Add(MakePresetButton("Plugins server", "Paper", "Normal", "Survival", enableGeyser: false));
+            presets.Children.Add(MakePresetButton("Java mods", "Fabric", "Normal", "Survival", enableGeyser: false));
+            presets.Children.Add(MakePresetButton("Bedrock server", "Bedrock (BDS)", "Easy", "Survival", enableGeyser: false));
+            presets.Children.Add(MakePresetButton("Cross-play server", "Paper", "Easy", "Survival", enableGeyser: true));
+            root.Children.Add(presets);
+
+            var advancedNote = new TextBlock
+            {
+                Text = "Advanced fields remain below for seed, world type, loader version, and custom worlds.",
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 11,
+                Foreground = FindResource("TextFillColorTertiaryBrush") as Brush,
+                Margin = new Thickness(0, 10, 0, 0)
+            };
+            root.Children.Add(advancedNote);
+
+            card.Content = root;
+            ContentLayoutRoot.Children.Insert(0, card);
+            _goalPresetsInstalled = true;
+        }
+
+        private Wpf.Ui.Controls.Button MakePresetButton(string label, string serverType, string difficulty, string gamemode, bool enableGeyser)
+        {
+            var button = new Wpf.Ui.Controls.Button
+            {
+                Content = label,
+                Appearance = Wpf.Ui.Controls.ControlAppearance.Secondary,
+                Margin = new Thickness(0, 0, 8, 8),
+                Padding = new Thickness(12, 6, 12, 6),
+                Cursor = System.Windows.Input.Cursors.Hand,
+                ToolTip = $"Use {serverType} with {gamemode}/{difficulty} defaults."
+            };
+            button.Click += (_, _) => ApplyGoalPreset(serverType, difficulty, gamemode, enableGeyser);
+            return button;
+        }
+
+        private void ApplyGoalPreset(string serverType, string difficulty, string gamemode, bool enableGeyser)
+        {
+            SelectComboBoxItemByContent(CmbServerType, serverType);
+            SelectComboBoxItemByContent(CmbDifficulty, difficulty);
+            SelectComboBoxItemByContent(CmbGamemode, gamemode);
+
+            if (TxtMaxPlayers != null && string.IsNullOrWhiteSpace(TxtMaxPlayers.Text))
+            {
+                TxtMaxPlayers.Text = "20";
+            }
+
+            if (ChkEnableGeyser != null)
+            {
+                ChkEnableGeyser.IsChecked = enableGeyser;
+            }
+        }
+
+        private static void SelectComboBoxItemByContent(ComboBox comboBox, string content)
+        {
+            foreach (object item in comboBox.Items)
+            {
+                if (item is ComboBoxItem comboBoxItem && string.Equals(comboBoxItem.Content?.ToString(), content, StringComparison.OrdinalIgnoreCase))
+                {
+                    comboBox.SelectedItem = comboBoxItem;
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/PocketMC.Desktop/Features/InstanceCreation/NewInstancePage.xaml
+++ b/PocketMC.Desktop/Features/InstanceCreation/NewInstancePage.xaml
@@ -2,7 +2,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-      Title="New Instance"
+      Title="New Server"
       SizeChanged="Page_SizeChanged">
 
     <Grid Margin="28,20,28,24" VerticalAlignment="Stretch">
@@ -17,9 +17,7 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <StackPanel Grid.Column="0"
-                        Orientation="Horizontal"
-                        HorizontalAlignment="Left">
+            <StackPanel Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left">
                 <ui:Button Content="Back"
                            Appearance="Secondary"
                            Icon="{ui:SymbolIcon ArrowLeft24}"
@@ -27,14 +25,19 @@
                            Margin="0,0,14,0"
                            Click="BtnBack_Click"/>
 
-                <ui:TextBlock FontTypography="Title"
-                              Text="Create a New Instance"
-                              Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                              VerticalAlignment="Center"/>
+                <StackPanel VerticalAlignment="Center">
+                    <ui:TextBlock FontTypography="Title"
+                                  Text="Create a New Server"
+                                  Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                    <TextBlock Text="Choose a sensible preset, then tune details only when you actually need to. Shocking concept."
+                               FontSize="12"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"/>
+                </StackPanel>
             </StackPanel>
 
             <ui:Button Grid.Column="1"
-                       Content="Import Instance"
+                       Content="Import Server"
                        Appearance="Secondary"
                        Icon="{ui:SymbolIcon ArrowUpload24}"
                        MinWidth="136"
@@ -43,7 +46,6 @@
                        Click="BtnImportInstance_Click"/>
         </Grid>
 
-        <!-- Footer Action Bar -->
         <Border DockPanel.Dock="Bottom"
                 Margin="0,16,0,0"
                 Padding="20,16"
@@ -58,7 +60,6 @@
                 </Grid.ColumnDefinitions>
 
                 <Grid Grid.Column="0" Margin="0,0,24,0" VerticalAlignment="Center">
-                    <!-- Error Callout -->
                     <Border x:Name="ErrorCallout"
                             HorizontalAlignment="Left"
                             Visibility="Collapsed"
@@ -68,71 +69,39 @@
                             CornerRadius="14"
                             Padding="12">
                         <StackPanel Orientation="Horizontal">
-                            <Border Width="8"
-                                    Height="8"
-                                    Background="#FFB4AB"
-                                    CornerRadius="4"
-                                    Margin="0,5,10,0"
-                                    VerticalAlignment="Top"/>
-                            <TextBlock x:Name="TxtError"
-                                       Foreground="#FFE8E6"
-                                       TextWrapping="Wrap"
-                                       VerticalAlignment="Center"/>
+                            <Border Width="8" Height="8" Background="#FFB4AB" CornerRadius="4" Margin="0,5,10,0" VerticalAlignment="Top"/>
+                            <TextBlock x:Name="TxtError" Foreground="#FFE8E6" TextWrapping="Wrap" VerticalAlignment="Center"/>
                         </StackPanel>
                     </Border>
 
-                    <!-- Progress Overlay (moved to footer) -->
                     <StackPanel x:Name="ProgressOverlay" Visibility="Collapsed" VerticalAlignment="Center" HorizontalAlignment="Stretch">
                         <Grid Margin="0,0,0,6">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            
                             <StackPanel Orientation="Horizontal" Grid.Column="0" VerticalAlignment="Center">
-                                <ui:ProgressRing Width="16"
-                                                 Height="16"
-                                                 IsIndeterminate="True"
-                                                 Margin="0,0,8,0"
-                                                 VerticalAlignment="Center"/>
-                                <TextBlock Text="Preparing your server files..."
+                                <ui:ProgressRing Width="16" Height="16" IsIndeterminate="True" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                                <TextBlock Text="Creating server..."
                                            VerticalAlignment="Center"
                                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                            FontWeight="SemiBold"
                                            FontSize="13"/>
                             </StackPanel>
-                            
                             <TextBlock x:Name="TxtProgress"
                                        Grid.Column="1"
-                                       Text="Waiting for download..."
+                                       Text="1/6 Preparing server folder..."
                                        FontSize="12"
                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center"/>
                         </Grid>
-                        
-                        <ProgressBar x:Name="PrgDownload"
-                                     Minimum="0"
-                                     Maximum="100"
-                                     Height="4"
-                                     Margin="0,0,0,0"
-                                     VerticalAlignment="Center"/>
+                        <ProgressBar x:Name="PrgDownload" Minimum="0" Maximum="100" Height="4" Margin="0,0,0,0" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Grid>
 
-                <StackPanel Grid.Column="1"
-                            Orientation="Horizontal"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Center">
-                    <ui:Button x:Name="BtnCancel"
-                               Content="Cancel"
-                               Appearance="Secondary"
-                               Margin="0,0,8,0"
-                               Click="BtnBack_Click"/>
-                    <ui:Button x:Name="BtnCreate"
-                               Content="Create and Download"
-                               Appearance="Primary"
-                               Icon="{ui:SymbolIcon ArrowDownload24}"
-                               Click="BtnCreate_Click"/>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <ui:Button x:Name="BtnCancel" Content="Cancel" Appearance="Secondary" Margin="0,0,8,0" Click="BtnBack_Click"/>
+                    <ui:Button x:Name="BtnCreate" Content="Create and Download" Appearance="Primary" Icon="{ui:SymbolIcon ArrowDownload24}" Click="BtnCreate_Click"/>
                 </StackPanel>
             </Grid>
         </Border>
@@ -141,9 +110,21 @@
             <ScrollViewer x:Name="Scroller" VerticalScrollBarVisibility="Auto">
                 <StackPanel x:Name="ContentLayoutRoot" MaxWidth="980" HorizontalAlignment="Stretch">
 
-            <ui:Card x:Name="FormCard"
-                     Padding="24"
-                     Margin="0">
+            <ui:Card Padding="18" Margin="0,0,0,14">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <ui:SymbolIcon Grid.Column="0" Symbol="Lightbulb24" FontSize="22" Foreground="{DynamicResource SystemFillColorAttentionBrush}" Margin="0,2,12,0"/>
+                    <StackPanel Grid.Column="1">
+                        <TextBlock Text="Not sure what to choose?" FontWeight="SemiBold" Foreground="{DynamicResource TextFillColorPrimaryBrush}" Margin="0,0,0,4"/>
+                        <TextBlock Text="Start with Paper for a fast Java server with plugins. Pick Fabric/Forge/NeoForge only when you need Java mods. Pick Bedrock BDS for official Bedrock servers. PocketMine is for Bedrock plugin servers." TextWrapping="Wrap" Foreground="{DynamicResource TextFillColorSecondaryBrush}" FontSize="12"/>
+                    </StackPanel>
+                </Grid>
+            </ui:Card>
+
+            <ui:Card x:Name="FormCard" Padding="24" Margin="0">
                 <Grid x:Name="InputsPanel">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition x:Name="Col0" Width="*" />
@@ -158,92 +139,46 @@
                         <RowDefinition x:Name="Row4" Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <!-- Left Column: Basics & Compliance -->
                     <StackPanel x:Name="LeftPanel" Grid.Column="0" Grid.Row="0">
-                        <TextBlock Text="Basics"
-                                   FontSize="12"
-                                   FontWeight="SemiBold"
-                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                   Margin="0,0,0,16"/>
+                        <TextBlock Text="Basics" FontSize="12" FontWeight="SemiBold" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,0,0,16"/>
 
-                        <!-- Server Name -->
-                        <TextBlock Text="Server Name"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ui:TextBox x:Name="TxtName"
-                                    PlaceholderText="My Cool Server"
-                                    Margin="0,0,0,16"/>
+                        <TextBlock Text="Server Name" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ui:TextBox x:Name="TxtName" PlaceholderText="My Cool Server" Margin="0,0,0,16"/>
 
-                        <!-- Description -->
-                        <TextBlock Text="Description"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ui:TextBox x:Name="TxtDescription"
-                                    PlaceholderText="What this instance is for"
-                                    Margin="0,0,0,16"/>
+                        <TextBlock Text="Description" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ui:TextBox x:Name="TxtDescription" PlaceholderText="What this server is for" Margin="0,0,0,16"/>
 
-                        <!-- Server Type -->
-                        <TextBlock Text="Server Type"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ComboBox x:Name="CmbServerType"
-                                  Margin="0,0,0,16"
-                                  HorizontalAlignment="Stretch"
-                                  MinHeight="40"
-                                  SelectionChanged="CmbServerType_SelectionChanged">
-                            <ComboBoxItem Content="Vanilla" IsSelected="True"/>
-                            <ComboBoxItem Content="Paper"/>
+                        <TextBlock Text="Server Type" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ComboBox x:Name="CmbServerType" Margin="0,0,0,6" HorizontalAlignment="Stretch" MinHeight="40" SelectionChanged="CmbServerType_SelectionChanged">
+                            <ComboBoxItem Content="Vanilla"/>
+                            <ComboBoxItem Content="Paper" IsSelected="True"/>
                             <ComboBoxItem Content="Fabric"/>
                             <ComboBoxItem Content="Forge"/>
                             <ComboBoxItem Content="NeoForge"/>
                             <ComboBoxItem Content="Bedrock (BDS)"/>
                             <ComboBoxItem Content="Pocketmine (PHP)"/>
                         </ComboBox>
-
-                        <!-- Minecraft Version -->
-                        <TextBlock Text="Minecraft Version"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ComboBox x:Name="CmbVersion"
-                                  Margin="0,0,0,8"
-                                  HorizontalAlignment="Stretch"
-                                  MinHeight="40"
-                                  DisplayMemberPath="Id"
-                                  SelectionChanged="CmbVersion_SelectionChanged"/>
-                        
-                        <TextBlock x:Name="TxtVersionState"
-                                   Text="Choose a server type to load available versions."
+                        <TextBlock Text="Paper is recommended for most Java servers. Vanilla is official but less flexible. Fabric/Forge/NeoForge are for mods. Bedrock BDS and PocketMine are Bedrock-only choices."
                                    FontSize="11"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap"
                                    Margin="0,0,0,16"/>
 
-                        <!-- Snapshots & Warnings -->
-                        <CheckBox x:Name="ChkShowSnapshots"
-                                  Content="Show snapshots and pre-releases"
-                                  Checked="ChkShowSnapshots_Changed"
-                                  Unchecked="ChkShowSnapshots_Changed"
-                                  Margin="0,0,0,8"/>
-                        
-                        <TextBlock x:Name="TxtForgeWarning"
-                                   Visibility="Collapsed"
-                                   Foreground="#F9E2AF"
-                                   FontSize="12"
-                                   TextWrapping="Wrap"
-                                   Margin="0,0,0,16"/>
+                        <TextBlock Text="Minecraft Version" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ComboBox x:Name="CmbVersion" Margin="0,0,0,8" HorizontalAlignment="Stretch" MinHeight="40" DisplayMemberPath="Id" SelectionChanged="CmbVersion_SelectionChanged"/>
+                        <TextBlock x:Name="TxtVersionState" Text="Choose a server type to load available versions." FontSize="11" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" Margin="0,0,0,16"/>
 
-                        <!-- Loader Version -->
+                        <CheckBox x:Name="ChkShowSnapshots" Content="Show snapshots and pre-releases" Checked="ChkShowSnapshots_Changed" Unchecked="ChkShowSnapshots_Changed" Margin="0,0,0,8"/>
+                        <TextBlock Text="Snapshots can break worlds and mods. Use them for testing, not for the server your friends already emotionally depend on." FontSize="11" Foreground="{DynamicResource TextFillColorTertiaryBrush}" TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+                        <TextBlock x:Name="TxtForgeWarning" Visibility="Collapsed" Foreground="#F9E2AF" FontSize="12" TextWrapping="Wrap" Margin="0,0,0,16"/>
+
                         <StackPanel x:Name="LoaderVersionPanel" Visibility="Collapsed" Margin="0,8,0,16">
-                            <TextBlock Text="Loader Version"
-                                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                       Margin="0,0,0,6"/>
-                               <ComboBox x:Name="CmbLoaderVersion"
-                                      HorizontalAlignment="Stretch"
-                                      MinHeight="40"
-                                      DisplayMemberPath="Version"/>
+                            <TextBlock Text="Loader Version" Foreground="{DynamicResource TextFillColorPrimaryBrush}" Margin="0,0,0,6"/>
+                            <ComboBox x:Name="CmbLoaderVersion" HorizontalAlignment="Stretch" MinHeight="40" DisplayMemberPath="Version"/>
+                            <TextBlock Text="Keep the latest loader unless a mod specifically tells you otherwise." FontSize="11" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" Margin="0,6,0,0"/>
                         </StackPanel>
 
-                        <!-- Addon Panel (Cross-play) -->
                         <StackPanel x:Name="AddonPanel" Margin="0,8,0,16">
                             <Border Height="1" Background="{DynamicResource CardStrokeColorDefaultBrush}" Margin="0,8,0,16"/>
                             <Grid>
@@ -251,152 +186,77 @@
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <CheckBox x:Name="ChkEnableGeyser"
-                                          Grid.Column="0"
-                                          VerticalAlignment="Top"
-                                          Margin="0,2,12,0"/>
-                                
+                                <CheckBox x:Name="ChkEnableGeyser" Grid.Column="0" VerticalAlignment="Top" Margin="0,2,12,0"/>
                                 <StackPanel Grid.Column="1">
-                                    <TextBlock Text="Enable Cross-play (Geyser + Floodgate)"
-                                               FontWeight="Medium"
-                                               FontSize="13"
-                                               Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                               Margin="0,0,0,4"/>
-                                    <TextBlock FontSize="12"
-                                               Opacity="0.8"
-                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                               TextWrapping="Wrap">
-                                        <Run Text="Allows Minecraft Bedrock players to join this Java server."/>
+                                    <TextBlock Text="Enable Cross-play (Geyser + Floodgate)" FontWeight="Medium" FontSize="13" Foreground="{DynamicResource TextFillColorPrimaryBrush}" Margin="0,0,0,4"/>
+                                    <TextBlock FontSize="12" Opacity="0.8" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextWrapping="Wrap">
+                                        <Run Text="Allows Minecraft Bedrock players to join this Java server. This may require an additional public Bedrock address."/>
                                     </TextBlock>
                                 </StackPanel>
                             </Grid>
                         </StackPanel>
-
                     </StackPanel>
 
-                    <!-- Right Column: World & Gameplay Settings -->
                     <StackPanel x:Name="RightPanel" Grid.Column="2" Grid.Row="0">
-                        <TextBlock Text="World &amp; Gameplay Settings"
-                                   FontSize="12"
-                                   FontWeight="SemiBold"
-                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                   Margin="0,0,0,16"/>
+                        <TextBlock Text="World &amp; Gameplay Settings" FontSize="12" FontWeight="SemiBold" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,0,0,16"/>
 
-                        <!-- World Seed -->
-                        <TextBlock Text="World Seed"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ui:TextBox x:Name="TxtSeed"
-                                    PlaceholderText="Leave empty for random seed"
-                                    Margin="0,0,0,16"/>
+                        <TextBlock Text="World Seed" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ui:TextBox x:Name="TxtSeed" PlaceholderText="Leave empty for random seed" Margin="0,0,0,16"/>
 
-                        <!-- World Generation Type -->
-                        <TextBlock Text="World Generation Type"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ComboBox x:Name="CmbLevelType"
-                                  Margin="0,0,0,16"
-                                  HorizontalAlignment="Stretch"
-                                  MinHeight="40">
+                        <TextBlock Text="World Generation Type" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ComboBox x:Name="CmbLevelType" Margin="0,0,0,16" HorizontalAlignment="Stretch" MinHeight="40">
                             <ComboBoxItem Content="Default" IsSelected="True"/>
                             <ComboBoxItem Content="Flat"/>
                             <ComboBoxItem Content="LargeBiomes"/>
                             <ComboBoxItem Content="Amplified"/>
                         </ComboBox>
 
-                        <!-- Default Gamemode -->
-                        <TextBlock Text="Default Gamemode"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ComboBox x:Name="CmbGamemode"
-                                  Margin="0,0,0,16"
-                                  HorizontalAlignment="Stretch"
-                                  MinHeight="40">
+                        <TextBlock Text="Default Gamemode" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ComboBox x:Name="CmbGamemode" Margin="0,0,0,16" HorizontalAlignment="Stretch" MinHeight="40">
                             <ComboBoxItem Content="Survival" IsSelected="True"/>
                             <ComboBoxItem Content="Creative"/>
                             <ComboBoxItem Content="Adventure"/>
                             <ComboBoxItem Content="Spectator"/>
                         </ComboBox>
 
-                        <!-- World Difficulty -->
-                        <TextBlock Text="World Difficulty"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ComboBox x:Name="CmbDifficulty"
-                                  Margin="0,0,0,16"
-                                  HorizontalAlignment="Stretch"
-                                  MinHeight="40">
+                        <TextBlock Text="World Difficulty" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ComboBox x:Name="CmbDifficulty" Margin="0,0,0,16" HorizontalAlignment="Stretch" MinHeight="40">
                             <ComboBoxItem Content="Peaceful"/>
                             <ComboBoxItem Content="Easy" IsSelected="True"/>
                             <ComboBoxItem Content="Normal"/>
                             <ComboBoxItem Content="Hard"/>
                         </ComboBox>
 
-                        <!-- Players Limit -->
-                        <TextBlock Text="Players Limit"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-                        <ui:TextBox x:Name="TxtMaxPlayers"
-                                    Text="20"
-                                    Margin="0,0,0,16"/>
+                        <TextBlock Text="Players Limit" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ui:TextBox x:Name="TxtMaxPlayers" Text="20" Margin="0,0,0,16"/>
 
-                        <!-- Custom World Upload -->
-                        <TextBlock Text="Custom World Upload (.zip / .mcworld)"
-                                   Margin="0,0,0,6"
-                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <TextBlock Text="Custom World Upload (.zip / .mcworld)" Margin="0,0,0,6" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <ui:TextBox x:Name="TxtCustomWorldPath"
-                                        PlaceholderText="Optional (.zip / .mcworld)"
-                                        IsReadOnly="True"
-                                        Margin="0,0,8,0"/>
-                            <ui:Button x:Name="BtnBrowseWorld"
-                                       Grid.Column="1"
-                                       Content="Browse"
-                                       Appearance="Secondary"
-                                       MinHeight="40"
-                                       Click="BtnBrowseWorld_Click"/>
+                            <ui:TextBox x:Name="TxtCustomWorldPath" PlaceholderText="Optional (.zip / .mcworld)" IsReadOnly="True" Margin="0,0,8,0"/>
+                            <ui:Button x:Name="BtnBrowseWorld" Grid.Column="1" Content="Browse" Appearance="Secondary" MinHeight="40" Click="BtnBrowseWorld_Click"/>
                         </Grid>
-
+                        <TextBlock Text="PocketMC will import the selected world after the server software is downloaded." FontSize="11" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" Margin="0,8,0,0"/>
                     </StackPanel>
 
-                    <!-- Bottom Row: Compliance & EULA -->
                     <StackPanel x:Name="CompliancePanel" Grid.Column="0" Grid.Row="4" Grid.ColumnSpan="3">
                         <Border Height="1" Background="{DynamicResource CardStrokeColorDefaultBrush}" Margin="0,8,0,16"/>
-                        <TextBlock Text="Compliance"
-                                   FontSize="12"
-                                   FontWeight="SemiBold"
-                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                   Margin="0,0,0,12"/>
-
+                        <TextBlock Text="Compliance" FontSize="12" FontWeight="SemiBold" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,0,0,12"/>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <CheckBox x:Name="ChkAcceptEula"
-                                      Grid.Column="0"
-                                      VerticalAlignment="Top"
-                                      Margin="0,2,12,0"
-                                      Checked="ChkAcceptEula_Changed"
-                                      Unchecked="ChkAcceptEula_Changed"/>
-                            
+                            <CheckBox x:Name="ChkAcceptEula" Grid.Column="0" VerticalAlignment="Top" Margin="0,2,12,0" Checked="ChkAcceptEula_Changed" Unchecked="ChkAcceptEula_Changed"/>
                             <StackPanel Grid.Column="1">
-                                <TextBlock Text="I accept the Minecraft End User License Agreement"
-                                           FontWeight="Medium"
-                                           FontSize="13"
-                                           Margin="0,0,0,4"/>
-                                <TextBlock FontSize="12"
-                                           Opacity="0.8"
-                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                           TextWrapping="Wrap">
+                                <TextBlock Text="I accept the Minecraft End User License Agreement" FontWeight="Medium" FontSize="13" Margin="0,0,0,4"/>
+                                <TextBlock FontSize="12" Opacity="0.8" Foreground="{DynamicResource TextFillColorSecondaryBrush}" TextWrapping="Wrap">
                                     <Run Text="PocketMC will write eula.txt automatically. Review "/>
-                                    <Hyperlink NavigateUri="https://aka.ms/MinecraftEULA"
-                                               RequestNavigate="MinecraftEulaLink_RequestNavigate">Mojang's EULA</Hyperlink>
-                                    <Run Text=" before creating the instance."/>
+                                    <Hyperlink NavigateUri="https://aka.ms/MinecraftEULA" RequestNavigate="MinecraftEulaLink_RequestNavigate">Mojang's EULA</Hyperlink>
+                                    <Run Text=" before creating the server."/>
                                 </TextBlock>
                             </StackPanel>
                         </Grid>

--- a/PocketMC.Desktop/Features/Settings/ServerSettingsPage.Search.cs
+++ b/PocketMC.Desktop/Features/Settings/ServerSettingsPage.Search.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 
 namespace PocketMC.Desktop.Features.Settings
 {
@@ -32,7 +31,11 @@ namespace PocketMC.Desktop.Features.Settings
             {
                 sidebarHost.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
                 sidebarHost.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
-                Grid.SetRow(SidebarList, 1);
+
+                foreach (UIElement child in sidebarHost.Children)
+                {
+                    Grid.SetRow(child, 1);
+                }
             }
 
             _settingsSearchBox = new Wpf.Ui.Controls.TextBox
@@ -44,6 +47,7 @@ namespace PocketMC.Desktop.Features.Settings
             };
             _settingsSearchBox.TextChanged += SettingsSearchBox_TextChanged;
 
+            Grid.SetColumn(_settingsSearchBox, Grid.GetColumn(SidebarList));
             Grid.SetRow(_settingsSearchBox, 0);
             sidebarHost.Children.Add(_settingsSearchBox);
 

--- a/PocketMC.Desktop/Features/Settings/ServerSettingsPage.Search.cs
+++ b/PocketMC.Desktop/Features/Settings/ServerSettingsPage.Search.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace PocketMC.Desktop.Features.Settings
+{
+    public partial class ServerSettingsPage
+    {
+        private Wpf.Ui.Controls.TextBox? _settingsSearchBox;
+
+        protected override void OnInitialized(EventArgs e)
+        {
+            base.OnInitialized(e);
+            Loaded += ServerSettingsPage_SearchLoaded;
+        }
+
+        private void ServerSettingsPage_SearchLoaded(object sender, RoutedEventArgs e)
+        {
+            InstallSettingsSearchBox();
+        }
+
+        private void InstallSettingsSearchBox()
+        {
+            if (_settingsSearchBox != null || SidebarList?.Parent is not Grid sidebarHost)
+            {
+                return;
+            }
+
+            if (sidebarHost.RowDefinitions.Count == 0)
+            {
+                sidebarHost.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                sidebarHost.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+                Grid.SetRow(SidebarList, 1);
+            }
+
+            _settingsSearchBox = new Wpf.Ui.Controls.TextBox
+            {
+                PlaceholderText = "Search settings...",
+                Margin = new Thickness(0, 0, 0, 12),
+                MinHeight = 38,
+                ToolTip = "Search by RAM, backup, difficulty, port, icon, MOTD, mods, plugins, AI, crash, or update."
+            };
+            _settingsSearchBox.TextChanged += SettingsSearchBox_TextChanged;
+
+            Grid.SetRow(_settingsSearchBox, 0);
+            sidebarHost.Children.Add(_settingsSearchBox);
+
+            RenameSettingsNavigationForClarity();
+        }
+
+        private void RenameSettingsNavigationForClarity()
+        {
+            SetNavContent(0, "Basic · Identity & Performance");
+            SetNavContent(1, "Content · Version Updates");
+            SetNavContent(2, "Basic · Gameplay Rules");
+            SetNavContent(3, "Content · World & Files");
+            SetNavContent(4, "Content · Addons");
+            SetNavContent(5, "Safety · Backups");
+            SetNavContent(6, "Safety · Fault Tolerance");
+            SetNavContent(7, "Advanced · Editor");
+            SetNavContent(8, "Advanced · AI Summaries");
+        }
+
+        private void SetNavContent(int index, string content)
+        {
+            if (SidebarList.MenuItems.Count > index && SidebarList.MenuItems[index] is Wpf.Ui.Controls.NavigationViewItem item)
+            {
+                item.Content = content;
+            }
+        }
+
+        private void SettingsSearchBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            string query = _settingsSearchBox?.Text?.Trim() ?? string.Empty;
+
+            for (int i = 0; i < SidebarList.MenuItems.Count; i++)
+            {
+                if (SidebarList.MenuItems[i] is not Wpf.Ui.Controls.NavigationViewItem item)
+                {
+                    continue;
+                }
+
+                bool visible = string.IsNullOrWhiteSpace(query) || NavItemMatchesSearch(i, item.Content?.ToString() ?? string.Empty, query);
+                item.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
+            }
+
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                ActivateFirstVisibleSearchResult();
+            }
+        }
+
+        private static bool NavItemMatchesSearch(int index, string label, string query)
+        {
+            string keywords = index switch
+            {
+                0 => "identity performance name description icon motd ram memory java startup auto start",
+                1 => "version update upgrade rollback minecraft loader paper fabric forge neoforge bedrock",
+                2 => "gameplay rules difficulty gamemode whitelist allowlist players pvp spawn command blocks",
+                3 => "world files folder seed level type import export properties port",
+                4 => "addons mods plugins marketplace modrinth curseforge install update dependency",
+                5 => "backup backups restore snapshot safety automatic schedule",
+                6 => "fault tolerance restart crash watchdog auto restart failure resilience",
+                7 => "advanced editor server properties config raw dangerous",
+                8 => "ai summaries summary intelligence logs provider privacy token",
+                _ => string.Empty
+            };
+
+            return label.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                   keywords.Contains(query, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void ActivateFirstVisibleSearchResult()
+        {
+            for (int i = 0; i < SidebarList.MenuItems.Count; i++)
+            {
+                if (SidebarList.MenuItems[i] is Wpf.Ui.Controls.NavigationViewItem item && item.Visibility == Visibility.Visible)
+                {
+                    MainTabControl.SelectedIndex = i;
+
+                    foreach (var menuItem in SidebarList.MenuItems.OfType<Wpf.Ui.Controls.NavigationViewItem>())
+                    {
+                        menuItem.IsActive = false;
+                    }
+
+                    item.IsActive = true;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/PocketMC.Desktop/Features/Tunnel/TunnelPage.SimpleMode.cs
+++ b/PocketMC.Desktop/Features/Tunnel/TunnelPage.SimpleMode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 
 namespace PocketMC.Desktop.Features.Tunnel

--- a/PocketMC.Desktop/Features/Tunnel/TunnelPage.SimpleMode.cs
+++ b/PocketMC.Desktop/Features/Tunnel/TunnelPage.SimpleMode.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace PocketMC.Desktop.Features.Tunnel
+{
+    public partial class TunnelPage
+    {
+        private bool _simpleModeInstalled;
+        private Wpf.Ui.Controls.Card? _simpleModeCard;
+        private Button? _toggleAdvancedButton;
+        private bool _advancedTunnelDetailsVisible;
+
+        protected override void OnInitialized(EventArgs e)
+        {
+            base.OnInitialized(e);
+            Loaded += TunnelPage_SimpleModeLoaded;
+        }
+
+        private void TunnelPage_SimpleModeLoaded(object sender, RoutedEventArgs e)
+        {
+            InstallSimpleMode();
+        }
+
+        private void InstallSimpleMode()
+        {
+            if (_simpleModeInstalled || Content is not Grid rootGrid)
+            {
+                return;
+            }
+
+            TxtStatusDetail.Text = "Use the setup steps below to make servers reachable outside your Wi-Fi.";
+
+            _simpleModeCard = new Wpf.Ui.Controls.Card
+            {
+                Padding = new Thickness(20),
+                Margin = new Thickness(0, 0, 0, 16)
+            };
+            Grid.SetRow(_simpleModeCard, 1);
+
+            var root = new StackPanel();
+            root.Children.Add(new TextBlock
+            {
+                Text = "Make my server public",
+                FontSize = 18,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = FindResource("TextFillColorPrimaryBrush") as Brush,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            root.Children.Add(new TextBlock
+            {
+                Text = "PocketMC uses Playit to create public join addresses. Follow the steps in order instead of guessing which button does what, a radical user-interface innovation.",
+                TextWrapping = TextWrapping.Wrap,
+                Foreground = FindResource("TextFillColorSecondaryBrush") as Brush,
+                FontSize = 13,
+                Margin = new Thickness(0, 0, 0, 14)
+            });
+
+            var steps = new UniformGrid { Columns = 4, Margin = new Thickness(0, 0, 0, 14) };
+            steps.Children.Add(MakeStep("1", "Download", "Install the Playit helper."));
+            steps.Children.Add(MakeStep("2", "Setup", "Link your Playit account."));
+            steps.Children.Add(MakeStep("3", "Connect", "Start the public connection."));
+            steps.Children.Add(MakeStep("4", "Share", "Copy the join address."));
+            root.Children.Add(steps);
+
+            var actionRow = new WrapPanel { Orientation = Orientation.Horizontal };
+            actionRow.Children.Add(MakeActionButton("Download Agent", Wpf.Ui.Controls.SymbolRegular.ArrowDownload24, Wpf.Ui.Controls.ControlAppearance.Primary, BtnDownloadAgent_Click));
+            actionRow.Children.Add(MakeActionButton("Setup Agent", Wpf.Ui.Controls.SymbolRegular.PersonAdd24, Wpf.Ui.Controls.ControlAppearance.Secondary, BtnSetupAgent_Click));
+            actionRow.Children.Add(MakeActionButton("Connect", Wpf.Ui.Controls.SymbolRegular.Play24, Wpf.Ui.Controls.ControlAppearance.Secondary, BtnConnect_Click));
+            actionRow.Children.Add(MakeActionButton("Refresh", Wpf.Ui.Controls.SymbolRegular.ArrowSync24, Wpf.Ui.Controls.ControlAppearance.Secondary, BtnRefresh_Click));
+
+            _toggleAdvancedButton = new Button
+            {
+                Content = "Show advanced tunnel controls",
+                Margin = new Thickness(0, 0, 8, 8),
+                Padding = new Thickness(12, 6, 12, 6),
+                Cursor = System.Windows.Input.Cursors.Hand
+            };
+            _toggleAdvancedButton.Click += ToggleAdvancedTunnelDetails_Click;
+            actionRow.Children.Add(_toggleAdvancedButton);
+            root.Children.Add(actionRow);
+
+            root.Children.Add(new TextBlock
+            {
+                Text = "Danger zone actions like deleting the agent stay in advanced controls so nobody nukes their setup while trying to invite a friend.",
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 11,
+                Foreground = FindResource("TextFillColorTertiaryBrush") as Brush,
+                Margin = new Thickness(0, 4, 0, 0)
+            });
+
+            _simpleModeCard.Content = root;
+
+            foreach (UIElement child in rootGrid.Children)
+            {
+                if (Grid.GetRow(child) == 1)
+                {
+                    Grid.SetRow(child, 2);
+                }
+                else if (Grid.GetRow(child) == 2)
+                {
+                    Grid.SetRow(child, 3);
+                }
+            }
+
+            if (rootGrid.RowDefinitions.Count < 4)
+            {
+                rootGrid.RowDefinitions.Insert(1, new RowDefinition { Height = GridLength.Auto });
+            }
+
+            rootGrid.Children.Add(_simpleModeCard);
+            SetAdvancedTunnelDetailsVisible(false);
+            _simpleModeInstalled = true;
+        }
+
+        private Border MakeStep(string number, string title, string description)
+        {
+            var stack = new StackPanel { Margin = new Thickness(8, 0, 8, 0) };
+            stack.Children.Add(new TextBlock
+            {
+                Text = number,
+                FontSize = 20,
+                FontWeight = FontWeights.Bold,
+                Foreground = FindResource("SystemFillColorAttentionBrush") as Brush,
+                HorizontalAlignment = HorizontalAlignment.Center
+            });
+            stack.Children.Add(new TextBlock
+            {
+                Text = title,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = FindResource("TextFillColorPrimaryBrush") as Brush,
+                HorizontalAlignment = HorizontalAlignment.Center
+            });
+            stack.Children.Add(new TextBlock
+            {
+                Text = description,
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                TextAlignment = TextAlignment.Center,
+                Foreground = FindResource("TextFillColorSecondaryBrush") as Brush
+            });
+
+            return new Border
+            {
+                Background = FindResource("ControlFillColorDefaultBrush") as Brush,
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(10),
+                Margin = new Thickness(0, 0, 8, 0),
+                Child = stack
+            };
+        }
+
+        private Wpf.Ui.Controls.Button MakeActionButton(string content, Wpf.Ui.Controls.SymbolRegular symbol, Wpf.Ui.Controls.ControlAppearance appearance, RoutedEventHandler handler)
+        {
+            var button = new Wpf.Ui.Controls.Button
+            {
+                Content = content,
+                Icon = new Wpf.Ui.Controls.SymbolIcon { Symbol = symbol },
+                Appearance = appearance,
+                Margin = new Thickness(0, 0, 8, 8),
+                Cursor = System.Windows.Input.Cursors.Hand
+            };
+            button.Click += handler;
+            return button;
+        }
+
+        private void ToggleAdvancedTunnelDetails_Click(object sender, RoutedEventArgs e)
+        {
+            SetAdvancedTunnelDetailsVisible(!_advancedTunnelDetailsVisible);
+        }
+
+        private void SetAdvancedTunnelDetailsVisible(bool visible)
+        {
+            _advancedTunnelDetailsVisible = visible;
+            if (_toggleAdvancedButton != null)
+            {
+                _toggleAdvancedButton.Content = visible ? "Hide advanced tunnel controls" : "Show advanced tunnel controls";
+            }
+
+            TxtExecutablePath.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
+            BtnDisconnect.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
+            BtnDeleteAgent.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
+        }
+    }
+}

--- a/docs/ux-improvement-plan.md
+++ b/docs/ux-improvement-plan.md
@@ -1,0 +1,466 @@
+# PocketMC UI/UX Improvement Plan
+
+This document captures the highest-impact UI/UX changes needed to make PocketMC easier, safer, and more confidence-building for users managing Minecraft servers on Windows.
+
+The focus is on problems that can block users, cause destructive mistakes, or make the app feel confusing even when the underlying feature works correctly.
+
+## Goals
+
+- Make the first server creation flow beginner-friendly without removing advanced power.
+- Make server connection status obvious: local play, public play, Java, and Bedrock should not feel like a scavenger hunt.
+- Reduce destructive mistakes around deleting servers, worlds, agents, and configuration.
+- Make start failures, crashes, port conflicts, and tunnel issues actionable.
+- Improve responsive layouts for smaller windows and high-DPI Windows scaling.
+- Use user-facing terminology consistently: prefer **server** over **instance** in UI copy unless the context is technical.
+
+## Priority P0: User-blocking UX issues
+
+### 1. Dashboard server clarity
+
+Current dashboard cards expose a lot of powerful state, but users mainly need to answer: **Can my friends join?**
+
+Recommended changes:
+
+- Rename dashboard heading from `Instances` to `Servers`.
+- Rename `New Instance` to `New Server`.
+- Add a dashboard empty state when no servers exist:
+
+```text
+No servers yet
+Create your first Minecraft server or import an existing one.
+[Create Server] [Import Server]
+```
+
+- Add a clear connection summary for running servers:
+
+```text
+Join address for friends outside your Wi-Fi
+abc.playit.gg:12345 [Copy]
+
+LAN address for players on the same Wi-Fi
+192.168.1.5:25565 [Copy]
+
+Bedrock address
+1.2.3.4:19132 [Copy]
+```
+
+- Add one primary action: `Copy Invite Message`.
+
+Suggested invite message format:
+
+```text
+Join my Minecraft server:
+Java: abc.playit.gg:12345
+Bedrock: 1.2.3.4:19132
+Version: 1.21.5
+```
+
+### 2. Server health panel
+
+Add a health checklist visible from dashboard cards and console:
+
+```text
+Server Health
+✅ Server process running
+✅ Java ready
+✅ Enough RAM
+✅ Port available
+✅ Public address ready
+⚠ Backup recommended
+❌ Last crash detected
+
+[Fix issues]
+```
+
+This should be powered by existing checks where possible:
+
+- server lifecycle state
+- Java configuration
+- memory availability
+- port reliability checks
+- tunnel/agent state
+- latest crash report detection
+- backup availability
+
+### 3. Safer delete flow
+
+Delete confirmation should clearly explain what is being deleted and require stronger intent.
+
+Recommended copy:
+
+```text
+Delete "Survival Server" permanently?
+
+This deletes:
+- World files
+- Server config
+- Installed mods/plugins
+- Logs
+
+Type DELETE to confirm.
+```
+
+Rules:
+
+- Keep delete actions visually separated in a `Danger Zone`.
+- Use danger styling only for destructive actions.
+- Never place `Delete Agent` beside routine tunnel actions like `Connect` or `Refresh`.
+
+### 4. Version loading recovery
+
+When loading versions fails, the user should not only see a raw exception.
+
+Recommended UI:
+
+```text
+Could not load Paper versions from PaperMC.
+Check your internet connection or try again.
+
+[Retry] [Use cached versions] [Open diagnostics]
+```
+
+Implementation notes:
+
+- Keep raw exception text behind `Details`.
+- Display the provider that failed.
+- Allow retry from the same page without changing server type.
+- Prefer cached versions if available.
+
+### 5. Stage-based creation progress
+
+Replace vague progress with visible stages:
+
+```text
+1/6 Creating folder
+2/6 Downloading server software
+3/6 Writing server.properties
+4/6 Installing optional addons
+5/6 Importing world
+6/6 Final checks
+```
+
+Special cases:
+
+- Forge/NeoForge should show: `Running Forge installer. This can take several minutes.`
+- Bedrock BDS should show extraction progress separately from download progress.
+- Geyser/Floodgate provisioning should have its own stage when cross-play is enabled.
+
+## Priority P1: Reduce beginner confusion
+
+### 6. Convert server creation into a guided flow
+
+The current creation page exposes basics, server type, version, snapshots, loader version, cross-play, world settings, custom world upload, and EULA at once.
+
+Recommended flow:
+
+1. **Choose server goal**
+2. **Choose version**
+3. **Optional settings**
+4. **Review and create**
+
+Suggested first step options:
+
+```text
+Vanilla survival with friends
+Plugins server
+Mods server
+Bedrock server
+Import existing server
+```
+
+Map those choices to sensible defaults:
+
+- Vanilla survival with friends -> Paper or Vanilla, depending on product decision.
+- Plugins server -> Paper.
+- Mods server -> Fabric/Forge/NeoForge picker.
+- Bedrock server -> Bedrock BDS or PocketMine choice.
+- Import existing server -> import flow.
+
+### 7. Explain server type choices
+
+Replace bare server type names with helpful labels:
+
+```text
+Vanilla - official Minecraft server
+Paper - plugins and better performance
+Fabric - lightweight Java mods
+Forge - classic Java mods
+NeoForge - newer Forge-style mods
+Bedrock BDS - official Bedrock server
+PocketMine - Bedrock plugin server
+```
+
+Add a `Not sure?` helper:
+
+```text
+Want plugins? Choose Paper.
+Want Java mods? Choose Fabric or Forge.
+Want Bedrock players? Choose Bedrock BDS or enable Cross-play.
+Want the safest beginner option? Choose Paper.
+```
+
+### 8. Improve import discoverability
+
+Import is currently reachable from the new instance flow, but it should also be visible from the dashboard.
+
+Recommended dashboard actions:
+
+```text
+[Create Server] [Import Server]
+```
+
+### 9. Pre-flight start checklist
+
+Before starting a server, show a compact checklist when there are warnings or blockers:
+
+```text
+Java installed
+Enough RAM available
+Server file exists
+EULA accepted
+Port available
+Tunnel ready
+World folder valid
+```
+
+Turn existing start-time dialogs into visible checks where practical.
+
+### 10. Better port conflict UX
+
+When a port conflict blocks start/restart, show cause and fixes:
+
+```text
+Port 25565 is already in use.
+
+Likely cause:
+Another Minecraft server or Java process is running.
+
+Fix options:
+[Use another port]
+[Find process using port]
+[Open advanced help]
+```
+
+Avoid exposing low-level binding text as the primary message.
+
+## Priority P2: Console, tunnel, and settings polish
+
+### 11. Console responsiveness
+
+The console top bar has many controls. On smaller windows, collapse secondary controls into overflow.
+
+Primary controls:
+
+```text
+Back | Search logs | Stop Server | Send command
+```
+
+Overflow controls:
+
+```text
+Auto-scroll
+Copy logs
+Filters
+Regex
+Players
+Restart
+AI Summary
+```
+
+Collapse log filters into one control:
+
+```text
+Filter: All / Chat / Info / Warnings / Errors / System
+```
+
+### 12. Console read-only affordance
+
+When showing last session logs:
+
+- Change title to `Console: Last session`.
+- Change command placeholder to `Start the server to send commands`.
+- Keep the existing informational banner.
+
+### 13. AI privacy disclosure
+
+Before first AI log analysis or AI summary, show:
+
+```text
+This sends selected log text to your configured AI provider.
+Do not send private IPs, tokens, or sensitive chat logs.
+```
+
+Add a setting:
+
+```text
+Redact IP addresses and player UUIDs before AI analysis
+```
+
+### 14. Tunnel simple mode
+
+Most users do not think in terms of agents and origins. First-run tunnel UX should be task-based:
+
+```text
+Make my server public
+Step 1: Download Playit agent
+Step 2: Sign in / claim agent
+Step 3: Create address
+Step 4: Copy address to friends
+```
+
+Terminology changes:
+
+- `Agent Status` -> `Public connection status`
+- `Tunnel` -> `Public connection`
+- Hide agent executable path under advanced details.
+- Move `Delete Agent` into a danger zone.
+
+State-dependent actions:
+
+- Missing agent -> `Download Agent`
+- Downloaded but not setup -> `Setup Agent`
+- Setup but disconnected -> `Connect`
+- Connected -> `Disconnect`
+
+### 15. Settings hierarchy and search
+
+The server settings page has many sections. Add settings search and group navigation into clearer buckets.
+
+Recommended groups:
+
+```text
+Basic
+- Identity
+- Performance
+- Gameplay
+
+Content
+- World & Files
+- Addons
+- Version Updates
+
+Safety & Advanced
+- Backups
+- Fault Tolerance
+- AI Summaries
+- Advanced Editor
+```
+
+Add:
+
+```text
+Search settings...
+```
+
+Search should match terms like RAM, backup, difficulty, port, icon, MOTD, mods, plugins, AI, crash, and update.
+
+### 16. Separate settings save from update actions
+
+Do not mix global `Save Changes` with version update actions in the same visual group.
+
+Recommended:
+
+- Global footer: `Discard changes` and `Save settings`.
+- Version tab card: `Preview update`, `Apply update`, `Rollback previous update`.
+
+## Crash recovery improvements
+
+When a crash is detected, show actionable recovery options:
+
+```text
+Server crashed
+Likely cause: Missing mod dependency / Java mismatch / port conflict / out of memory
+
+[View crash report]
+[Copy report]
+[Open mods folder]
+[Restore backup]
+[Ask AI to explain]
+```
+
+Also surface crash reason on the dashboard card, not only inside console.
+
+## Modded server safe mode
+
+For Fabric, Forge, and NeoForge servers, add recovery actions:
+
+```text
+Start without mods
+Disable recently added mods
+Open mods folder
+Restore backup
+```
+
+This should be especially visible after a crash caused by mod loading errors.
+
+## Backup prompts before risky operations
+
+Prompt users to create a backup before:
+
+- Minecraft version update
+- loader version change
+- bulk mod/plugin changes
+- world replacement/import
+- advanced config edits
+- deleting world files
+
+Recommended prompt:
+
+```text
+Create backup first?
+Recommended before this change.
+
+[Create backup and continue]
+[Continue without backup]
+```
+
+Do not show this for safe edits like description changes.
+
+## Terminology standards
+
+Prefer user-facing language:
+
+| Current | Preferred |
+| --- | --- |
+| Instance | Server |
+| New Instance | New Server |
+| Import Instance | Import Server |
+| Server Configurations | Server Settings |
+| Agent | Playit connection helper |
+| Tunnel | Public connection |
+| Public Address | Join address |
+
+Use `instance` only in code, logs, and advanced/internal contexts.
+
+## Implementation checklist
+
+### Safe first PR candidates
+
+- [ ] Rename dashboard visible copy from `Instances` to `Servers`.
+- [ ] Add dashboard empty state.
+- [ ] Add `Import Server` action near `Create Server`.
+- [ ] Add clearer copy labels around tunnel/LAN/Bedrock addresses.
+- [ ] Add copy feedback for address buttons.
+- [ ] Strengthen delete confirmation copy.
+- [ ] Add retry button for version loading failures.
+- [ ] Add first-run AI privacy notice.
+
+### Larger follow-up PRs
+
+- [ ] Server creation wizard.
+- [ ] Server health panel.
+- [ ] Pre-flight start checklist.
+- [ ] Console responsive overflow toolbar.
+- [ ] Tunnel simple mode.
+- [ ] Settings search.
+- [ ] Crash recovery flow.
+- [ ] Modded server safe mode.
+
+## Acceptance criteria
+
+- A first-time user can create a recommended server without understanding Paper/Fabric/Forge internals.
+- A running server card clearly shows which address to share with friends.
+- Destructive actions require deliberate confirmation.
+- Common failures provide fixes, not just errors.
+- Console and settings remain usable on smaller windows and high-DPI displays.
+- AI-powered features disclose what data may be sent before first use.


### PR DESCRIPTION
## Summary

Expands the UX PR from a dashboard/creation polish slice into a broader architecture pass across dashboard, creation, console, tunnel, and settings.

### Implemented

#### Dashboard

- Renames dashboard-facing copy from instances toward servers.
- Adds dashboard `Create Server` and `Import Server` actions.
- Adds first-time empty state.
- Adds clearer server card join-address labels:
  - Java/Bedrock public join address
  - LAN address
  - Bedrock/Geyser address
  - numeric fallback addresses
- Adds `Copy Invite Message` on running server cards.
- Adds visible copy feedback for address/invite buttons.
- Adds basic server health summary text on cards.
- Improves destructive delete confirmation copy.
- Improves start/restart/port-failure messaging with actionable next steps.
- Adds stronger AI log-summary privacy disclosure before sending logs to an AI provider.

#### New Server creation

- Improves New Server page copy and beginner guidance.
- Defaults new Java server creation toward Paper instead of Vanilla.
- Adds goal-based presets as a wizard-lite layer:
  - Survival with friends
  - Plugins server
  - Java mods
  - Bedrock server
  - Cross-play server
- Adds clearer descriptions for server type choices, snapshots, loader versions, cross-play, and custom world import.
- Updates visible copy from instance to server where relevant.

#### Console

- Adds a runtime-injected responsive toolbar to replace the rigid 10-column console toolbar.
- Adds quick log filtering for All/Chat/Info/Warnings/Errors/System.
- Adds read-only command placeholder copy: `Start the server to send commands`.
- Adds recovery shortcuts in code for opening server/mods folders.
- Adds safer AI summary entry point with privacy confirmation.

#### Tunnel

- Adds simple-mode tunnel setup guidance.
- Adds task-based public connection steps:
  1. Download agent
  2. Setup agent
  3. Connect
  4. Share address
- Adds simplified primary actions.
- Hides advanced/danger tunnel controls until expanded.
- Separates dangerous agent deletion from the normal setup path.

#### Settings

- Adds searchable settings navigation as a runtime layer.
- Adds keyword matching for RAM, backups, difficulty, port, icon, MOTD, mods, plugins, AI, crash, updates, etc.
- Renames sidebar items into clearer Basic / Content / Safety / Advanced groups.

#### Planning

- Adds `docs/ux-improvement-plan.md` with priorities, acceptance criteria, and follow-up notes.

### Still intentionally not fully implemented

These need deeper lifecycle/service-level work and should not be faked in UI-only patches:

- True modded safe mode that starts without mods by temporarily isolating mod files safely.
- Full health-check engine backed by Java/RAM/port/tunnel/backups diagnostics.
- Fully redesigned creation wizard replacing the existing form.
- Backup-before-risky-change workflows across all settings mutations.
- Full crash classification engine for missing dependencies, Java mismatch, OOM, and port conflicts.

## Known caveats

- I could not run the build locally in this environment.
- One attempted icon-only patch was blocked by the platform tool filter, so `Lightbulb24` remains in `NewInstancePage.xaml`; verify the WPF UI symbol exists during build. If CI fails, replace it with a known symbol such as `Cube24`.
- The injected console toolbar is present, but the new Auto-scroll toggle may not fully sync with the original hidden toggle until verified locally.

## Testing

- Not run locally in this environment.
- Sanity-checked changed file list via GitHub compare.
- PR remains draft until CI/build validation confirms the WPF partials and symbol names compile cleanly.
