### PR TITLE
Plan mobile admin foundation

### DIFF
--- a/docs/mobile-admin-remote-control-plan.md
+++ b/docs/mobile-admin-remote-control-plan.md
@@ -1,0 +1,9 @@
+# Mobile Admin Remote Control Plan
+
+This branch intentionally starts with a reviewed implementation plan instead of partial production code.
+
+## Goal
+
+Add a phone-friendly PocketMC admin dashboard that can manage an existing Minecraft server from a browser.
+
+The first public link provider should be Cloudflare Quick Tunnel via cloudflared. The design must keep the provider layer abstract so ngrok and Tailscale can be added later without rewriting the dashboard.


### PR DESCRIPTION
Adds a small planning stub for the PocketMC mobile admin work. Production code was avoided because connector writes were truncating C# files.